### PR TITLE
chore: add LICENSE, CHANGELOG, CONTRIBUTING, SECURITY for public repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+For versions prior to the introduction of this changelog, see the
+[tag history](https://github.com/Estabilis/estabilis-platform-gitops/tags)
+and the corresponding commit messages.
+
+## [Unreleased]
+
+## Versioning
+
+- **Major** (`v1.0.0`) — breaking chart interface changes
+- **Minor** (`v0.X.0`) — new components or values, backward-compatible
+- **Patch** (`v0.X.Y`) — bug fixes, value tweaks, documentation
+
+Consumers pin the version via `repoVersion: "vX.Y.Z"` in their
+`workload-bootstrap` values overlay. See
+[CONTRIBUTING.md](CONTRIBUTING.md#release-process) for the release
+workflow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,106 @@
+# Contributing
+
+This repository is public but **not currently accepting pull requests**.
+Development happens through internal workflows. If you find a problem or
+have a suggestion, please open an issue — we read all of them.
+
+## Reporting issues
+
+Open an issue at
+[github.com/Estabilis/estabilis-platform-gitops/issues](https://github.com/Estabilis/estabilis-platform-gitops/issues)
+and include:
+
+- **What you observed** — ArgoCD logs, Application status, `kubectl` output
+  where relevant
+- **What you expected** — the behavior you believed correct
+- **Environment** — ArgoCD version, workload cluster Kubernetes version,
+  chart version (see [`workload-bootstrap/Chart.yaml`](workload-bootstrap/Chart.yaml))
+- **How to reproduce** — minimal values overlay or chart snippet if possible
+
+**Security-sensitive issues:** do not open a public issue. See
+[SECURITY.md](SECURITY.md).
+
+## Pull requests
+
+External pull requests are not currently accepted. PRs will be closed with
+a reference to this document; please open an issue instead so we can
+discuss the problem. If we agree that the change is welcome, we may
+invite a PR at that point.
+
+---
+
+## Internal development (for maintainers)
+
+This section documents the local setup and gates that apply to anyone
+with write access to this repository.
+
+### Prerequisites
+
+| Tool | Purpose | Install |
+|------|---------|---------|
+| [just](https://just.systems/) | Task runner | `brew install just` / `cargo install just` |
+| [pre-commit](https://pre-commit.com/) | Git hooks | `pip install --user pre-commit` |
+
+### Setup
+
+```bash
+git clone https://github.com/Estabilis/estabilis-platform-gitops.git
+cd estabilis-platform-gitops
+just install    # installs pre-commit and activates the git hooks
+```
+
+### Local checks
+
+```bash
+just lint       # ApplicationSet template lint (scoped to goTemplate files)
+just lint-all   # runs all pre-commit hooks on every file in the repo
+```
+
+CI (`.github/workflows/lint.yml`) runs the same gates on every pull
+request and push to `main`, so `git commit --no-verify` bypasses are
+caught at PR time.
+
+### Branch and commit conventions
+
+- Branch from `main`. Prefixes: `feat/`, `fix/`, `chore/`, `docs/`, `spike/`.
+- Commit messages follow the Conventional Commits format used in existing
+  history: `type(scope): description (vX.Y.Z)`. The version suffix is
+  optional for non-release commits.
+
+### Versioning
+
+This repo uses [Semantic Versioning](https://semver.org/). A release bumps
+**three artefacts in the same commit**:
+
+1. `workload-bootstrap/Chart.yaml` — both `version` and `appVersion`
+2. `workload-bootstrap/values.yaml` — `repoVersion` field
+3. A git tag `vX.Y.Z` matching the above
+
+Release cadence:
+
+- **Major** (`v1.0.0`) — breaking chart interface changes (removed values,
+  renamed templates, ApplicationSet selector changes)
+- **Minor** (`v0.X.0`) — new components, new values, backward-compatible
+  features
+- **Patch** (`v0.X.Y`) — bug fixes, value tweaks, documentation
+
+### Release process
+
+```bash
+# 1. Move [Unreleased] entries in CHANGELOG.md to the new version header
+# 2. Bump version + appVersion in workload-bootstrap/Chart.yaml
+# 3. Bump repoVersion in workload-bootstrap/values.yaml
+# 4. Commit
+git add CHANGELOG.md workload-bootstrap/
+git commit -m "release: vX.Y.Z"
+
+# 5. Tag
+git tag vX.Y.Z
+
+# 6. Push
+git push origin main --tags
+```
+
+Consumers pin the version via `repoVersion: "vX.Y.Z"` in their
+`workload-bootstrap` values overlay. An upstream bump without a
+consumer-side version bump has no effect.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,93 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor's trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to the
+software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is Estabilis.
+
+The **software** is Estabilis Platform.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that organization.
+**Control** means ownership of substantially all the assets of an entity, or the
+power to direct its management and policies by vote, contract, or otherwise.
+Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.
+
+**Trademark** means trademarks, service marks, and similar rights.

--- a/README.md
+++ b/README.md
@@ -29,45 +29,44 @@ This repo does NOT contain:
                                             │
                                             ▼
                   ┌─────────── workload cluster (spoke) ───────────┐
-                  │   Kyverno + estabilis labels/annotations       │
-                  │   (v0.1.0 — only this, nothing else yet)       │
+                  │   Baseline components (Kyverno, cert-manager,  │
+                  │   external-dns, Alloy, Traefik, …) rendered    │
+                  │   from this repo + estabilis labels            │
                   └────────────────────────────────────────────────┘
 ```
 
 ## Layout
 
 ```
-workload-bootstrap/            Helm chart that renders the ApplicationSet
-  Chart.yaml
-  values.yaml                  defaults (cluster selector, component versions)
+workload-bootstrap/            Helm chart that renders the ApplicationSets
+  Chart.yaml                   version + appVersion (bumped on every release)
+  values.yaml                  defaults (cluster selector, component toggles, repoVersion)
   templates/
     _helpers.tpl               estabilis.labels / annotations / metadata
-    applicationset.yaml        the ApplicationSet with cluster generator
+    *.yaml                     one ApplicationSet per workload component
 
-workload-components/           per-component values overlays
-  kyverno/
-    values.yaml                injected as $values into the upstream Kyverno chart
-
-docs/
-  architecture.md              this diagram + how to add a new component
+components/                    per-component Helm charts (values overlays + policies)
+values/                        platform/ and workload/ values files injected as $values
+docs/                          architecture notes
 ```
 
 ## Versioning
 
-Semver, starting from `v0.1.0`. Pinned in downstream overrides via
-`platform_gitops_version` (analog to `platform_version`). See
-`estabilis-platform-tools/docs/adr/0001-workload-bootstrap-strategy.md`.
+Semver. Pinned in downstream overrides via `repoVersion` in the
+`workload-bootstrap` values overlay. See [CHANGELOG.md](CHANGELOG.md) for
+the release history and [CONTRIBUTING.md](CONTRIBUTING.md#release-process)
+for the release workflow.
 
 ## How the hub consumes this repo
 
-The `estabilis-platform/bootstrap/platform-root/` chart has one
+The `estabilis-platform/bootstrap/platform-root/` chart contains one
 Application template (`workload-bootstrap.yaml`) that points here:
 
 ```yaml
 spec:
   source:
     repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-    targetRevision: v0.1.0
+    targetRevision: vX.Y.Z        # pinned per cluster (see CHANGELOG)
     path: workload-bootstrap
     helm:
       valueFiles:
@@ -78,17 +77,12 @@ Downstream clients override via
 `overrides/workload-bootstrap/values.yaml` in their own config repo,
 following the same pattern as `overrides/platform-root/values.yaml`.
 
-## Scope of v0.1.0
+## Current scope
 
-**Kyverno only** on workload clusters, with estabilis labels and
-annotations applied consistently with the platform v0.1.36 convention.
-
-Not in v0.1.0 (tracked in roadmap):
-- Alloy DaemonSet (needs auth decision for workload→hub remote_write)
-- OTel Operator
-- OpenCost on workload
-- kyverno-policies (the actual policies — v0.2.x)
-- Trivy Operator on workload
+The canonical list of components and their versions lives in
+[`workload-bootstrap/values.yaml`](workload-bootstrap/values.yaml) and
+the per-component templates under `workload-bootstrap/templates/`.
+Recent additions are tracked in [CHANGELOG.md](CHANGELOG.md).
 
 ## References
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security-sensitive reports.
+
+Use GitHub's [private vulnerability reporting](https://github.com/Estabilis/estabilis-platform-gitops/security/advisories/new)
+feature. This creates a private advisory that only repository maintainers
+can see. Include:
+
+- A description of the issue
+- Steps to reproduce (if applicable)
+- The affected chart version(s) — see
+  [`workload-bootstrap/Chart.yaml`](workload-bootstrap/Chart.yaml)
+- Your contact information for follow-up
+
+We aim to acknowledge receipt within 5 business days and will work with
+you on a coordinated disclosure timeline.
+
+## Scope
+
+This repository contains ArgoCD GitOps manifests and Helm templates that
+are applied to managed Kubernetes clusters. The following issue classes
+fall within scope:
+
+- Templates that would grant excessive or unintended RBAC
+- Manifests that could leak credentials, tokens, or other secrets
+- Values referencing untrusted sources (images, charts, repositories)
+- Supply-chain issues — unpinned references, compromised upstream
+  dependencies, missing provenance or integrity guarantees
+- Template-injection or parameter-passing bugs that a malicious input
+  could exploit
+
+## Out of scope
+
+- Issues in upstream Helm charts consumed by this repository — please
+  report those directly to their maintainers
+- Issues in ArgoCD itself — see the
+  [Argo CD security policy](https://github.com/argoproj/argo-cd/security)
+- Misconfiguration in downstream client overlays — those are the
+  respective client's responsibility
+
+## Supported versions
+
+Only the latest minor release line receives security fixes. See
+[`CHANGELOG.md`](CHANGELOG.md) for the current release.


### PR DESCRIPTION
## Summary
- LICENSE: Elastic License 2.0 (matches `estabilis-platform`)
- CHANGELOG.md: Keep a Changelog format, forward-only (historical versions reachable via tags)
- CONTRIBUTING.md: issues-only policy + internal dev workflow (prerequisites, setup, three-way release sync)
- SECURITY.md: GitHub private vulnerability reporting as primary channel
- README.md: removed stale "v0.1.0 only" scope, fixed `components/` path, updated to `repoVersion` field name

## Test plan
- [ ] CI workflows still green
- [ ] License is recognized in the GitHub repo overview after merge
- [ ] Links in CONTRIBUTING/SECURITY resolve (tags page, Chart.yaml, private advisories)
- [ ] Verify GitHub Settings → Code security → "Private vulnerability reporting" is enabled