### PR TITLE
chore(ci): add applicationset template lint (first spike)

### DIFF
--- a/.agent-notes/2026-04-17-applicationset-gotemplate-syntax.md
+++ b/.agent-notes/2026-04-17-applicationset-gotemplate-syntax.md
@@ -1,0 +1,122 @@
+---
+date: 2026-04-17
+category: template-convention
+severity: low-runtime / medium-future-risk
+related-commits:
+  - c7f7b06  # v0.19.2 — add spaces in `{{ index ... }}`
+  - c48bfec  # v0.19.3 — enable goTemplate, `{{name}}` → `{{ .name }}`
+related-files:
+  - workload-bootstrap/templates/client-apps.yaml
+gate:
+  - scripts/lint-applicationset-templates.sh
+  - .pre-commit-config.yaml
+  - .github/workflows/lint.yml
+---
+
+# ApplicationSet goTemplate syntax consistency
+
+## What happened
+
+Two production fixes (`c7f7b06`, `c48bfec`) resolved failures where the
+ArgoCD ApplicationSet controller could not render templates that used:
+
+1. `{{ index ... }}` without spaces under `goTemplate: true`
+2. `{{name}}` / `{{server}}` legacy placeholders under `goTemplate: true`
+   (undefined variable — needs `.name` / `.server`)
+
+The fixes established a convention: under `goTemplate: true`, every
+backtick-escaped inner template uses spaces after `{{` and before `}}`
+and a `.`-prefixed cluster-generator variable.
+
+One file, `workload-bootstrap/templates/client-apps.yaml`, predates that
+convention and uses `{{.path.basename}}`, `{{.name}}`, `{{.path.path}}` —
+correct dot prefix but no spaces. Go template parses this successfully.
+
+## Production verification
+
+Checked against a production hub cluster on 2026-04-17 (pre-fix state):
+
+```
+NAME                              SYNC STATUS   HEALTH STATUS
+dapr-<workload-cluster>           Synced        Healthy
+kong-<workload-cluster>           Synced        Healthy
+kong-plugins-<workload-cluster>   OutOfSync     Healthy
+```
+
+All ApplicationSet-generated wrappers render with the expected
+`{basename}-{clustername}` pattern. **No runtime failure was caused by
+the inconsistent syntax.** The `OutOfSync` on `kong-plugins-...` is
+unrelated manifest drift.
+
+## Root cause
+
+Convention was established retroactively, after `client-apps.yaml` was
+authored. No mechanical gate existed, so the divergence survived code
+review. Review could not catch it because:
+
+- Helm renders both `{{.X}}` and `{{ .X }}` identically (the controller
+  parses the inner template, not Helm)
+- ArgoCD logs no warning for either form
+- A reviewer mentally normalizes style differences across 10 files
+- A prompt like "use spaces under goTemplate" is aspirational — there is
+  no signal when it is violated
+
+## Why this is still worth a gate
+
+The lint enforces a convention that is not a runtime law, but it is the
+same gate that catches the genuinely broken patterns (`{{name}}` under
+goTemplate, `{{index ... "y"}}` that parses ambiguously in the controller).
+Maintaining a single style prevents future drift where a real bug hides
+behind visible style inconsistency.
+
+## Mechanical gate created
+
+- `scripts/lint-applicationset-templates.sh` — scoped to
+  `workload-bootstrap/templates/*.yaml`. Only lints files declaring
+  `goTemplate: true` (legacy-mode files legitimately use `{{name}}`).
+  Flags three classes:
+  1. `` `{{X `` (no space after `{{` inside a backtick-escaped string)
+  2. `` X}}` `` (no space before `}}` inside a backtick-escaped string)
+  3. `` `{{name}}` `` / `` `{{server}}` `` (legacy placeholder without
+     leading dot)
+- `.pre-commit-config.yaml` — local hook gated on changes to
+  `workload-bootstrap/templates/*.yaml`.
+- `.github/workflows/lint.yml` — CI on pull_request and push to main.
+  Catches `--no-verify` bypasses of the local hook.
+
+## Verification performed
+
+- `./scripts/lint-applicationset-templates.sh` passes on HEAD after four
+  stylistic whitespace changes to `client-apps.yaml` (no semantic change).
+- Running the same script against the pre-fix historical state reproduces
+  the original failures — confirming the regex matches the real bug, not
+  just the post-fix cleanup.
+- Running the script against a synthetic template that declares
+  `goTemplate: true` with `{{name}}` violations fails with a clear
+  report.
+
+## Residual risk
+
+- The lint accepts legacy-mode files (no `goTemplate: true` declaration)
+  using `{{name}}` / `{{server}}` without spaces or dots, because those
+  work under ApplicationSet's legacy substitution. Five templates remain
+  in this mode: `cert-manager.yaml`, `resource-quotas.yaml`,
+  `network-policies.yaml`, `kube-state-metrics.yaml`,
+  `client-kyverno-exceptions.yaml`. Migrating them to `goTemplate: true`
+  for uniformity is a candidate for a **follow-up spike**.
+- A template declaring `goTemplate: true` but still using `{{name}}` *is*
+  caught by this gate.
+- The lint does not validate that the rendered YAML is deployable — only
+  that its inner-template syntax is consistent. Runtime validation would
+  require a kind-based integration test, which is out of scope for this
+  spike.
+
+## Classification
+
+| | |
+|---|---|
+| Convention or runtime law | Convention (the specific violations found caused no runtime failure) |
+| Catches real bugs too? | Yes — `{{name}}` under goTemplate and `{{index ...}}` parse ambiguity |
+| Cost | ~1 hour of spike work, <50 ms per CI run |
+| Reversibility | `git revert` of the spike commit removes all artifacts |
+| ADR reference | Candidate primary example for ADR-0015 (agent-safe platform) |

--- a/.agent-notes/README.md
+++ b/.agent-notes/README.md
@@ -25,7 +25,41 @@ One file per incident, named `YYYY-MM-DD-<slug>.md`. Required sections:
 4. **Mechanical gate created** — files/tools, where they run
 5. **Verification performed** — how the gate was validated
 6. **Residual risk** — what the gate does NOT catch
-7. **Classification** — convention vs runtime requirement
+7. **Classification** — see framework below; include the verdict as a
+   table with one-sentence justification
+
+## Classification framework
+
+Every note MUST declare which class of gate it creates:
+
+**Runtime law.** Without the gate, the code fails at runtime — parse
+error, wrong behavior, data loss, security hole, outage. The gate
+prevents regression of a real bug.
+
+**Convention.** The code works either way, but the gate enforces
+uniformity. Value comes from reducing cognitive load across the
+codebase and from catching the subset of same-class violations that
+*are* runtime bugs.
+
+Both classes are legitimate and worth enforcing. The risk appears when
+they are mixed without labels:
+
+- Treating a convention as a law → false confidence that the gate
+  prevents bugs it does not catch.
+- Removing a convention because "the code works anyway" → drift that
+  eventually lets a real runtime-law violation hide behind acceptable
+  style noise.
+
+Required table in the Classification section of every note:
+
+```markdown
+| | |
+|---|---|
+| Convention or runtime law | <Convention \| Runtime law> — <one-sentence justification> |
+| Catches real bugs too? | <Yes: list of classes \| No, pure style> |
+| Cost to add | <rough estimate> |
+| Reversibility | <how to undo the gate> |
+```
 
 ## Relation to ADRs
 

--- a/.agent-notes/README.md
+++ b/.agent-notes/README.md
@@ -1,0 +1,42 @@
+# .agent-notes/
+
+Audit trail for AI-agent-assisted and human-authored development.
+
+Each note documents a specific incident, investigation, or convention
+and the **mechanical gate** (lint, test, schema, CI check) created in
+response. The note is the *why* that prevents a future agent or
+reviewer from removing the gate without understanding its purpose.
+
+## When to add a note
+
+- An incident, regression, or bug that could plausibly recur
+- A subtle convention that a new lint now enforces
+- An investigation that produced a reusable rule
+
+Do NOT add a note for one-off fixes with no pattern worth enforcing.
+
+## Format
+
+One file per incident, named `YYYY-MM-DD-<slug>.md`. Required sections:
+
+1. **What happened** — factual description
+2. **Root cause** — the structural reason, not the symptom
+3. **Why prompts or review wouldn't catch it** — the argument for a gate
+4. **Mechanical gate created** — files/tools, where they run
+5. **Verification performed** — how the gate was validated
+6. **Residual risk** — what the gate does NOT catch
+7. **Classification** — convention vs runtime requirement
+
+## Relation to ADRs
+
+- **ADRs** live centrally in `estabilis-platform-tools/docs/adr/` and
+  codify cross-repo decisions and principles.
+- **Agent notes** live per-repo and document specific incidents and
+  the local gates derived from them. An ADR may reference multiple
+  agent notes as its evidence base.
+
+## Relation to commits
+
+The commit that introduces a gate should reference its agent note in
+the body. The agent note, in turn, lists the commit(s) that motivated
+the gate.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  applicationset-templates:
+    name: ApplicationSet goTemplate syntax
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run lint
+        run: ./scripts/lint-applicationset-templates.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+# Pre-commit hooks — run locally before each commit.
+#
+# Install once per clone:
+#   pip install pre-commit
+#   pre-commit install
+#
+# CI enforces the same hooks via .github/workflows/lint.yml, so a local
+# `git commit --no-verify` bypass is caught at PR time.
+
+repos:
+  - repo: local
+    hooks:
+      - id: lint-applicationset-templates
+        name: ArgoCD ApplicationSet goTemplate syntax
+        entry: scripts/lint-applicationset-templates.sh
+        language: script
+        pass_filenames: false
+        files: ^workload-bootstrap/templates/.*\.yaml$

--- a/justfile
+++ b/justfile
@@ -1,0 +1,21 @@
+# Estabilis Platform GitOps — Development
+# Justfile para setup e checks locais antes de commit/PR.
+# A CI em .github/workflows/lint.yml aplica os mesmos hooks.
+
+default:
+    @just --list
+
+# Setup one-time: instala pre-commit e ativa os git hooks no clone atual
+install:
+    @command -v pre-commit >/dev/null 2>&1 || pip install --user pre-commit
+    pre-commit install
+    @echo "pre-commit ativado. Hooks rodam automaticamente em cada commit."
+
+# Roda o lint dos templates de ApplicationSet manualmente
+lint:
+    ./scripts/lint-applicationset-templates.sh
+
+# Roda todos os pre-commit hooks sobre TODOS os arquivos do repo
+# (útil antes de abrir PR para pegar drift histórico)
+lint-all:
+    pre-commit run --all-files

--- a/scripts/lint-applicationset-templates.sh
+++ b/scripts/lint-applicationset-templates.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# lint-applicationset-templates.sh
+#
+# Enforces ArgoCD ApplicationSet goTemplate syntax inside
+# `workload-bootstrap/templates/*.yaml`.
+#
+# Background: when an ApplicationSet declares `goTemplate: true`, the
+# controller reinterprets strings wrapped in backticks inside the outer
+# Helm template. That inner reinterpretation requires:
+#   1) spaces after `{{` and before `}}`
+#   2) a leading `.` on cluster generator variables (`.name`, `.server`)
+#
+# Without goTemplate, the legacy syntax `{{name}}` / `{{server}}` works.
+# This lint is therefore contextual: it only fires on files that declare
+# `goTemplate: true`, to avoid flagging legitimate legacy-mode templates.
+#
+# See: .agent-notes/2026-04-17-applicationset-gotemplate-syntax.md
+
+set -euo pipefail
+
+TEMPLATE_DIR="${LINT_TEMPLATE_DIR:-workload-bootstrap/templates}"
+
+if [ ! -d "$TEMPLATE_DIR" ]; then
+    echo "lint-applicationset-templates: directory not found: $TEMPLATE_DIR" >&2
+    exit 2
+fi
+
+exit_code=0
+checked=0
+skipped=0
+
+for file in "$TEMPLATE_DIR"/*.yaml; do
+    [ -f "$file" ] || continue
+
+    # Only lint ApplicationSets in goTemplate mode. Legacy-mode files
+    # legitimately use `{{name}}` without spaces or dot — skip them.
+    if ! grep -Eq '^[[:space:]]*goTemplate:[[:space:]]*true' "$file"; then
+        skipped=$((skipped + 1))
+        continue
+    fi
+    checked=$((checked + 1))
+
+    # Violation A: backtick immediately followed by `{{` with no space
+    # after the braces (e.g. `{{index ...`, `{{name}}`).
+    v_open=$(grep -nE '`\{\{[^ `]' "$file" || true)
+
+    # Violation B: `}}` immediately preceded by a non-space character
+    # and followed by a backtick (e.g. `...annotations"}}`).
+    v_close=$(grep -nE '[^ ]\}\}`' "$file" || true)
+
+    # Violation C: legacy placeholders inside backticks without leading
+    # dot. Required under goTemplate: true.
+    v_legacy=$(grep -nE '`\{\{(name|server)\}\}`' "$file" || true)
+
+    if [ -n "$v_open" ] || [ -n "$v_close" ] || [ -n "$v_legacy" ]; then
+        echo "[FAIL] $file"
+        [ -n "$v_open" ]   && printf '%s\n' "$v_open"   | sed 's/^/        missing space after {{ : /'
+        [ -n "$v_close" ]  && printf '%s\n' "$v_close"  | sed 's/^/        missing space before }}: /'
+        [ -n "$v_legacy" ] && printf '%s\n' "$v_legacy" | sed 's/^/        legacy placeholder needs leading dot: /'
+        echo
+        exit_code=1
+    fi
+done
+
+if [ "$exit_code" -eq 0 ]; then
+    echo "lint-applicationset-templates: OK (checked=$checked goTemplate files, skipped=$skipped legacy files)"
+else
+    echo "lint-applicationset-templates: FAIL — see violations above" >&2
+    echo "Reference: .agent-notes/2026-04-17-applicationset-gotemplate-syntax.md" >&2
+fi
+
+exit $exit_code

--- a/workload-bootstrap/templates/client-apps.yaml
+++ b/workload-bootstrap/templates/client-apps.yaml
@@ -42,13 +42,13 @@ spec:
                 - path: "platforms/{{ .Values.deploymentId }}/apps/*"
   template:
     metadata:
-      name: "{{`{{.path.basename}}`}}-{{`{{.name}}`}}"
+      name: "{{`{{ .path.basename }}`}}-{{`{{ .name }}`}}"
       annotations:
         argocd.argoproj.io/sync-wave: "10"
       labels:
-        estabilis.io/workload-cluster: "{{`{{.name}}`}}"
+        estabilis.io/workload-cluster: "{{`{{ .name }}`}}"
         estabilis.io/managed-by: client-gitops
-        estabilis.io/component: "{{`{{.path.basename}}`}}"
+        estabilis.io/component: "{{`{{ .path.basename }}`}}"
     spec:
       project: workload-infra
       sources:
@@ -57,7 +57,7 @@ spec:
         #    references its own Helm chart source).
         - repoURL: {{ .Values.clientGitopsRepoUrl | quote }}
           targetRevision: {{ .Values.clientGitopsRepoVersion | default "HEAD" | quote }}
-          path: "{{`{{.path.path}}`}}"
+          path: "{{`{{ .path.path }}`}}"
           directory:
             recurse: false
       destination:


### PR DESCRIPTION
## Summary

First mechanical gate for the agent-safe platform effort. Enforces a
convention, not a runtime law.

- **`scripts/lint-applicationset-templates.sh`** — contextual lint for ArgoCD ApplicationSet goTemplate syntax. Only checks files declaring `goTemplate: true`; legacy-mode files legitimately using `{{name}}` / `{{server}}` are skipped. Flags three violation classes inside backtick-escaped inner templates:
  1. `` `{{X `` (no space after `{{`)
  2. `` X}}` `` (no space before `}}`)
  3. `` `{{name}}` `` / `` `{{server}}` `` (legacy placeholder missing leading dot)
- **`.pre-commit-config.yaml`** — local hook gated on changes to `workload-bootstrap/templates/`
- **`.github/workflows/lint.yml`** — CI gate on `pull_request` and `push` to `main`
- **`justfile`** — `just install`, `just lint`, `just lint-all` recipes
- **`.agent-notes/`** — audit infrastructure with a **Classification framework** (runtime law vs convention) that all future notes must declare
- **First audit note** documents the `client-apps.yaml` alignment: 4 stylistic whitespace changes, no semantic change. Production was verified Healthy before the alignment (see note for evidence).

## Classification

**Convention** — the specific violations found caused no runtime failure (Go template accepts `{{.X}}` and `{{ .X }}` as equivalent), but the gate also catches the related runtime-law violations (`{{name}}` under goTemplate, `{{index …}}` parse ambiguity).

## Test plan

- [ ] CI lint job passes on this PR
- [ ] Running `./scripts/lint-applicationset-templates.sh` against pre-fix history (`9b1bf3f^`, before `c7f7b06`) correctly flags the files fixed in v0.19.2
- [ ] `just install` wires pre-commit; `just lint` reports 10 goTemplate / 9 legacy
- [ ] Introducing a synthetic `{{name}}` under `goTemplate: true` triggers the hook

## Follow-ups (documented, not in scope)

- Migrate the 5 legacy-mode templates (`cert-manager`, `resource-quotas`, `network-policies`, `kube-state-metrics`, `client-kyverno-exceptions`) to `goTemplate: true` for uniformity — candidate for a future spike.