### PR TITLE
fix: reapply spike 2 (helm trim-marker lint) via cherry-pick

### DIFF
--- a/.agent-notes/2026-04-17-helm-trim-markers-list-concatenation.md
+++ b/.agent-notes/2026-04-17-helm-trim-markers-list-concatenation.md
@@ -1,0 +1,127 @@
+---
+date: 2026-04-17
+category: helm-template-quirk / silent-failure
+severity: high-runtime
+related-commits:
+  - 5b79a2c  # v0.22.3 — removed the offending comment, external-dns
+             # cloudflare values now load correctly
+related-files:
+  - workload-bootstrap/templates/external-dns.yaml (pre-v0.22.3)
+gate:
+  - scripts/lint-helm-trim-markers.sh
+  - .pre-commit-config.yaml
+  - .github/workflows/lint.yml
+---
+
+# Helm trim-marker comments concatenate YAML list items
+
+## What happened
+
+A Go template comment with both trim markers — `{{- /* ... */ -}}` —
+was placed between two YAML list items inside an ApplicationSet
+`valueFiles` list:
+
+```yaml
+valueFiles:
+  - $values/values/workload/external-dns.yaml
+  {{- /* Provider-specific values file selected by bridge annotation */ -}}
+  - $values/values/workload/external-dns-{{ `{{ index .metadata.annotations "estabilis.io/bridge.dns-provider" }}` }}.yaml
+```
+
+Helm rendered the comment to empty and consumed the whitespace on both
+sides, producing:
+
+```yaml
+valueFiles:
+  - $values/values/workload/external-dns.yaml- $values/values/workload/external-dns-cloudflare.yaml
+```
+
+ArgoCD parsed that as a single `valueFiles` entry — a path that does
+not exist. With `ignoreMissingValueFiles: true` the error was swallowed
+silently. The upstream `external-dns` chart fell back to its default
+`provider: aws`, and the running pod tried to authenticate to the AWS
+IMDS endpoint while holding Cloudflare credentials. No DNS record was
+ever created in Cloudflare for the workload cluster.
+
+## Root cause
+
+Three compounding decisions produced a silent failure:
+
+1. **Template output**: `{{- ... -}}` trim markers on a comment render
+   to empty and remove all surrounding whitespace — including the
+   newlines that keep YAML list items separate.
+2. **ArgoCD setting**: `ignoreMissingValueFiles: true` suppresses the
+   "file not found" error that would otherwise fail the Application.
+3. **Chart default**: the upstream `external-dns` chart defaults to
+   `provider: aws`. Without the cloudflare values file loading, the
+   provider silently reverted to AWS.
+
+Each individually is a reasonable, documented behavior. The sum is a
+production Application reported `Synced / Healthy` while doing nothing
+useful.
+
+## Why prompts or review wouldn't catch it
+
+- `helm lint` accepts the template — the Go template syntax is valid.
+- `helm template` produces YAML that is *syntactically* valid; it
+  takes attention to notice that one list entry contains two paths
+  mashed together.
+- ArgoCD's UI shows `Synced / Healthy` for the Application because the
+  apply succeeded; the misbehavior is inside the workload pod.
+- Reviewers scan diffs line by line and treat `{{- ... -}}` as
+  "whitespace control" without simulating the render mentally in list
+  contexts.
+- A prompt like "be careful with trim markers" is aspirational — there
+  is no signal at commit or PR time when the rule is violated.
+
+## Mechanical gate created
+
+- `scripts/lint-helm-trim-markers.sh` — greps each file under
+  `workload-bootstrap/templates/` for the exact pattern
+  `{{- /* ... */ -}}` (comment with both trim markers). A comment with
+  both trim markers renders to empty and consumes whitespace on both
+  sides — almost never useful, and dangerous in YAML list contexts.
+- Hooks: runs from `.pre-commit-config.yaml` locally and
+  `.github/workflows/lint.yml` in CI.
+
+## Verification performed
+
+- `./scripts/lint-helm-trim-markers.sh` on current HEAD (post-fix
+  `5b79a2c`): 19 files checked, 0 violations → exit 0.
+- `./scripts/lint-helm-trim-markers.sh` against the file state at the
+  parent commit (`4ebecee`): correctly flags
+  `workload-bootstrap/templates/external-dns.yaml:33` with the exact
+  offending line.
+- Synthetic test with a minimal YAML file containing the pattern: the
+  lint fails; an adjacent file using `{{/* */}}` without trim markers
+  passes (safe alternative documented).
+
+## Residual risk
+
+This gate catches the **template-side** root cause, but the incident
+was amplified by two other layers that remain unguarded:
+
+- **`ignoreMissingValueFiles: true` without justification.** Many
+  templates use this setting for legitimate optional overlays. A
+  future gate should require an inline `# justify: ...` comment
+  explaining why silent skip is the correct behavior for each
+  occurrence — forcing the author to acknowledge the silencing.
+- **No render-time validation in CI.** A `helm template` step that
+  parsed the output and asserted structural invariants (every
+  `valueFiles` entry is a single path, each list item is well-formed)
+  would catch this plus an entire class of similar concatenation and
+  indentation bugs. Deferred to a dedicated render-check spike because
+  it requires `helm` in CI, chart dependency setup, and defining the
+  invariants.
+
+Both are candidates for follow-up spikes.
+
+## Classification
+
+| | |
+|---|---|
+| Convention or runtime law | **Runtime law** — production silently ran with the wrong DNS provider; no records were created, endpoints were unreachable by FQDN. |
+| Catches real bugs too? | Yes — catches the exact class that produced v0.22.3; narrow enough to have zero false positives on current templates. |
+| Cost to add | ~30 minutes (script + hooks + this note). |
+| Reversibility | `git revert` of the spike commits removes all artefacts; no persistent state. |
+| ADR reference | Second reference case for ADR-0015. A runtime-law gate, complementing the convention gate from the first spike. |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,3 +13,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run lint
         run: ./scripts/lint-applicationset-templates.sh
+
+  helm-trim-markers:
+    name: Helm trim-marker comments in YAML lists
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run lint
+        run: ./scripts/lint-helm-trim-markers.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,9 @@ repos:
         language: script
         pass_filenames: false
         files: ^workload-bootstrap/templates/.*\.yaml$
+      - id: lint-helm-trim-markers
+        name: Helm trim-marker comments in YAML lists
+        entry: scripts/lint-helm-trim-markers.sh
+        language: script
+        pass_filenames: false
+        files: ^workload-bootstrap/templates/.*\.yaml$

--- a/justfile
+++ b/justfile
@@ -11,9 +11,10 @@ install:
     pre-commit install
     @echo "pre-commit ativado. Hooks rodam automaticamente em cada commit."
 
-# Roda o lint dos templates de ApplicationSet manualmente
+# Roda todos os lints de template manualmente (ApplicationSet + trim markers)
 lint:
     ./scripts/lint-applicationset-templates.sh
+    ./scripts/lint-helm-trim-markers.sh
 
 # Roda todos os pre-commit hooks sobre TODOS os arquivos do repo
 # (útil antes de abrir PR para pegar drift histórico)

--- a/scripts/lint-helm-trim-markers.sh
+++ b/scripts/lint-helm-trim-markers.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# lint-helm-trim-markers.sh
+#
+# Flags Go template comments that use BOTH trim markers — `{{- /* */ -}}`.
+# A trim-marked comment renders to empty and consumes all surrounding
+# whitespace (including newlines). When placed between two YAML list
+# items, the two items collapse into a single (invalid) line, e.g.:
+#
+#   - $values/values/workload/external-dns.yaml        ─┐
+#   {{- /* Provider-specific file */ -}}                │  renders as:
+#   - $values/values/workload/external-dns-foo.yaml    ─┘  "- ...yaml- $values/..."
+#
+# That output is consumed by ArgoCD as a single valueFile path, which
+# does not exist; with `ignoreMissingValueFiles: true` the error is
+# swallowed silently and the chart falls back to defaults.
+#
+# Rule: never use `{{- /* */ -}}` (both trim markers on a comment).
+# If you need a comment, use `{{/* */}}` without trim markers, which is
+# safe in YAML list contexts. If you need to suppress a specific blank
+# line, use only one trim marker on a non-empty template construct.
+#
+# See: .agent-notes/2026-04-17-helm-trim-markers-list-concatenation.md
+
+set -euo pipefail
+
+TEMPLATE_DIR="${LINT_TEMPLATE_DIR:-workload-bootstrap/templates}"
+
+if [ ! -d "$TEMPLATE_DIR" ]; then
+    echo "lint-helm-trim-markers: directory not found: $TEMPLATE_DIR" >&2
+    exit 2
+fi
+
+exit_code=0
+checked=0
+
+for file in "$TEMPLATE_DIR"/*.yaml; do
+    [ -f "$file" ] || continue
+    checked=$((checked + 1))
+
+    # Match: {{-  /*  ... */  -}}
+    # Space-tolerant around the trim markers; comment body ignored.
+    violations=$(grep -nE '\{\{-[[:space:]]*/\*.*\*/[[:space:]]*-\}\}' "$file" || true)
+
+    if [ -n "$violations" ]; then
+        echo "[FAIL] $file"
+        printf '%s\n' "$violations" | sed 's/^/        trim-marked empty template eats surrounding whitespace: /'
+        echo
+        exit_code=1
+    fi
+done
+
+if [ "$exit_code" -eq 0 ]; then
+    echo "lint-helm-trim-markers: OK (checked=$checked files)"
+else
+    echo "lint-helm-trim-markers: FAIL — see violations above" >&2
+    echo "Reference: .agent-notes/2026-04-17-helm-trim-markers-list-concatenation.md" >&2
+fi
+
+exit $exit_code


### PR DESCRIPTION
## Summary

Spike 2's content (merged originally in PR #5) did not reach `main`. This PR re-applies it via cherry-pick. No semantic change from the original commit.

## What happened

PR #5 was opened with `spike/applicationset-template-lint` as its base (chained on top of spike 1). Merge order:

```
13:39:42 UTC — PR #4 (spike 1) merged to main        → spike 1 content on main
13:43:02 UTC — PR #5 (spike 2) merged into PR #4's branch → dead-end merge
```

When PR #4 merged to main, the spike 1 branch effectively stopped being a path to main. The later merge of PR #5 into that branch produced commit `a18ac52`, which is orphaned relative to `main`. GitHub's PR list reports "MERGED" because the merge event succeeded, but the content never propagated.

## What this PR does

Cherry-picks `ded16e8` (the spike 2 commit) from the orphaned branch onto a fresh branch targeting `main`. Validation:

- `just lint` runs both lints and both pass on this branch
- `scripts/lint-helm-trim-markers.sh` present with executable bit set
- Audit note `.agent-notes/2026-04-17-helm-trim-markers-list-concatenation.md` restored
- `.pre-commit-config.yaml`, `.github/workflows/lint.yml`, `justfile` extended with the second lint entry

## Process lesson

This is exactly the silent-apply-skip class the ADR-0015 framework targets, but at the GitHub process layer instead of ArgoCD:

> A state transition reported as successful ("MERGED") without the effect actually landing where expected (`main`).

Mitigations for future chained PRs:

1. Prefer rebasing chained branches onto `main` before merging the dependent PR
2. When a chain exists, merge the ancestor via merge-commit into `main` AND update the dependent PR's base to `main` before merging
3. Branch protection rule: block merges on `spike/*` branches (they should only be PR sources)

None of these are mechanical gates yet — candidate for a future Layer 3 harness investment in ADR-0015's Known open work.

## Test plan

- [ ] CI runs both lint jobs (applicationset + trim-marker) on this PR
- [ ] Local `just lint` reports both lints OK after merge
- [ ] `scripts/lint-helm-trim-markers.sh` exists and is executable on `main` after merge
- [ ] Running the trim-marker lint against the pre-fix tree (`4ebecee`) still catches `external-dns.yaml:33` (regression test)