### PR TITLE
fix(refs): replace default HEAD with required on client gitops refs + lint (v0.24.1)

### DIFF
--- a/.agent-notes/2026-04-18-pin-git-refs.md
+++ b/.agent-notes/2026-04-18-pin-git-refs.md
@@ -1,0 +1,154 @@
+---
+date: 2026-04-18
+category: supply-chain / reproducibility
+severity: high-runtime
+related-commits:
+  - (this spike — bumps v0.24.1)
+related-notes:
+  - 2026-04-17-applicationset-gotemplate-syntax.md  # first Convention gate
+  - 2026-04-17-helm-trim-markers-list-concatenation.md  # first Runtime-law gate
+  - 2026-04-18-ignore-missing-values-helper-consolidation.md  # uniformity-amplifier
+related-files:
+  - workload-bootstrap/templates/_helpers.tpl                  # gitopsSource helper
+  - workload-bootstrap/templates/client-kyverno-exceptions.yaml
+  - workload-bootstrap/templates/client-apps.yaml
+gate:
+  - scripts/lint-pin-git-refs.sh
+  - .pre-commit-config.yaml
+  - .github/workflows/lint.yml
+---
+
+# Pin all git references — no HEAD, main, or master fallbacks
+
+## What happened
+
+Four ApplicationSet template locations used the pattern
+`{{ .Values.clientGitopsRepoVersion | default "HEAD" }}` (or the
+`| quote`d form) as the `targetRevision` / `revision` value for a
+client's gitops repository:
+
+```yaml
+targetRevision: {{ .Values.clientGitopsRepoVersion | default "HEAD" | quote }}
+```
+
+Affected templates:
+
+| File | Line | Context |
+|---|---|---|
+| `workload-bootstrap/templates/_helpers.tpl` | 170 | `gitopsSource` helper used by all client-gitops Applications |
+| `workload-bootstrap/templates/client-kyverno-exceptions.yaml` | 44 | Per-cluster Application for client Kyverno exceptions |
+| `workload-bootstrap/templates/client-apps.yaml` | 40 | `git` generator `revision` |
+| `workload-bootstrap/templates/client-apps.yaml` | 59 | Template source `targetRevision` |
+
+If a cluster had `clientGitopsRepoUrl` set but the operator forgot to
+pin `clientGitopsRepoVersion`, the chart silently rendered
+`targetRevision: "HEAD"` — ArgoCD dutifully tracked whatever the
+upstream branch pointed at, with no indication that pinning was
+missing.
+
+## Why this is a runtime law, not a convention
+
+Running on `HEAD` is observable, but the failure modes are supply-chain
+material:
+
+1. **Reproducibility collapses.** There is no way to answer "what chart
+   version was running in cluster X at time Y?" after the fact, because
+   the answer depends on `HEAD` resolution order at the moment of
+   sync. A rollback target does not exist.
+2. **Audit trail is unverifiable.** Compliance or security reviews that
+   pin production to a known-good artefact cannot do so. Every sync
+   potentially upgrades to untested code.
+3. **Blast radius is unbounded.** A force-push, a bad merge, or a
+   mistaken commit to the upstream branch propagates immediately to
+   every cluster resolving `HEAD`. There is no canary, no phased
+   rollout, no opportunity to revert before impact.
+4. **Silent failure.** The cluster reports `Synced / Healthy` while
+   running untracked code. The ArgoCD UI shows the branch name but
+   not the SHA as a problem.
+
+The user's long-standing memory rule (`feedback_pin_all_refs`) already
+prohibited unpinned targetRevisions. This spike moves the rule from
+operator-memory (prose) to chart-contract (mechanical gate + render-time
+`required` failure).
+
+## Root cause
+
+Early authors of the client-gitops helpers added the `default "HEAD"`
+as a convenience for testing. The convenience was never removed. The
+helpers are inherited by every client-gitops Application, so the
+anti-pattern was invisibly replicated.
+
+## Why prompts or review wouldn't catch it
+
+- Helm renders `default "HEAD"` correctly — no lint warning.
+- ArgoCD accepts `targetRevision: "HEAD"` without complaint.
+- Code review treats `| default "HEAD"` as a defensive fallback
+  rather than as the explicit removal of pinning.
+- An operator's prose rule ("always pin refs") is an aspiration until a
+  gate rejects the pattern at commit time.
+
+## Mechanical gate created
+
+### Template-level: `required` instead of `default`
+
+The four occurrences now use:
+
+```yaml
+targetRevision: {{ required "clientGitopsRepoVersion is required when clientGitopsRepoUrl is set" .Values.clientGitopsRepoVersion | quote }}
+```
+
+This shifts detection from ArgoCD sync time (silent) to
+`helm template` / `helm lint` time (loud). A misconfigured cluster
+fails to render long before it can mis-sync.
+
+### Repo-level: `scripts/lint-pin-git-refs.sh`
+
+Flags any `default "(HEAD|main|master|latest)"` in
+`workload-bootstrap/templates/*.{yaml,tpl}`. Narrow and targeted: semver
+tags (`v1.2.3`) and commit SHAs do not collide with these tokens.
+
+Wired into `.pre-commit-config.yaml` (local), `.github/workflows/lint.yml`
+(CI), and `justfile` (`just lint`).
+
+## Verification performed
+
+- `./scripts/lint-pin-git-refs.sh` on post-fix HEAD: 20 files checked
+  (19 `.yaml` + 1 `.tpl`), 0 violations → exit 0.
+- Same script against the file tree at `main` before this spike:
+  correctly flags `_helpers.tpl:170`, `client-kyverno-exceptions.yaml:44`,
+  `client-apps.yaml:40`, `client-apps.yaml:59`.
+- `helm template` with `clientGitopsRepoUrl=<test> deploymentId=<test>`
+  (but no `clientGitopsRepoVersion`): fails with
+  `Error: execution error ... clientGitopsRepoVersion is required when clientGitopsRepoUrl is set`.
+- `helm template` with all three set: renders 53 `targetRevision`
+  entries cleanly.
+- `helm template` with none set: client templates gated-off correctly;
+  no error; no `targetRevision: HEAD` in the output.
+- The three pre-existing lints continue to pass.
+
+## Residual risk
+
+- **Scope limited to ApplicationSet templates in `workload-bootstrap/`.**
+  Other repositories (estabilis-platform, estabilis-workload) have
+  their own Applications with `targetRevision`. Each repo needs this
+  gate independently — not copied from here, installed per repo.
+- **Literal tokens only.** The lint flags `default "HEAD"`,
+  `default "main"`, etc. A variable-driven fallback
+  (`default .Values.someDefault`) where `someDefault` evaluates to
+  `HEAD` is not caught. None of this pattern exists today; a future
+  author attempting the bypass is caught at code review.
+- **No enforcement that values files pin semver tags.** The gate
+  enforces the *mechanism* (no default fallback), not the *value* set
+  by the consumer. A consumer setting `clientGitopsRepoVersion: main`
+  is still allowed. Defending against that is a separate spike, likely
+  requiring a JSON Schema or value validation helper.
+
+## Classification
+
+| | |
+|---|---|
+| Convention or runtime law | **Runtime law** — `targetRevision: HEAD` produces supply-chain material failure modes (lost reproducibility, broken audit, unbounded blast radius). The gate prevents regression of a real class. |
+| Catches real bugs too? | Yes — four active occurrences flagged against pre-fix `main`; each was a latent vulnerability for any cluster that set `clientGitopsRepoUrl` without `clientGitopsRepoVersion`. |
+| Cost to add | ~45 minutes total (recon, four template edits, lint script, integration, CHANGELOG, audit note). |
+| Reversibility | `git revert` of the spike commit restores the `default "HEAD"` fallbacks. The lint script is removed in the same revert. |
+| ADR reference | ADR-0015 Known open work #5 (pin-all-references lint). First runtime-law gate at the supply-chain layer (previous runtime-law gate was at the template-engine layer). |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,3 +29,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run lint
         run: ./scripts/lint-ignore-missing-inline.sh
+
+  pin-git-refs:
+    name: Pin all git references
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run lint
+        run: ./scripts/lint-pin-git-refs.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,9 @@ repos:
         language: script
         pass_filenames: false
         files: ^workload-bootstrap/templates/.*\.yaml$
+      - id: lint-pin-git-refs
+        name: Pin all git references (no HEAD/main/master fallbacks)
+        entry: scripts/lint-pin-git-refs.sh
+        language: script
+        pass_filenames: false
+        files: ^workload-bootstrap/templates/.*\.(yaml|tpl)$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,19 +11,57 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.24.1] — 2026-04-18
+
 ### Changed
 
-- Wire the new `lint-ignore-missing-inline` gate into pre-commit,
-  CI workflow, and `just lint`. The lint itself shipped in v0.23.1
-  but was not integrated into the automation layer until this entry.
-  No behavior change — the script was always runnable manually.
+- Replace `default "HEAD"` fallbacks on four client-gitops git
+  references with `required "..."` expressions. When a cluster sets
+  `clientGitopsRepoUrl` (and/or `deploymentId`) but does not set
+  `clientGitopsRepoVersion`, `helm template` now fails at render time
+  with a clear message — previously the chart silently fell back to
+  tracking `HEAD`, defeating reproducibility, audit, and blast-radius
+  control. Production deployments always pin the version and are
+  unaffected.
+
+  Affected templates:
+  - `workload-bootstrap/templates/_helpers.tpl` (`gitopsSource` helper)
+  - `workload-bootstrap/templates/client-kyverno-exceptions.yaml`
+  - `workload-bootstrap/templates/client-apps.yaml` (two occurrences)
+
+### Added
+
+- `scripts/lint-pin-git-refs.sh` — gate that flags
+  `default "(HEAD|main|master|latest)"` in templates under
+  `workload-bootstrap/templates/`. Wired into pre-commit, CI, and
+  `just lint`.
+
+### Documentation
+
+- `.agent-notes/2026-04-18-pin-git-refs.md` — audit note with full
+  Classification (Runtime law) per the ADR-0015 framework.
+
+## [0.24.0] — 2026-04-17
+
+### Added
+
+- Dynamic Alloy push URLs via bridge annotations.
+
+### Fixed
+
+- Alloy template trim marker + YAML escaping.
+
+### Changed
+
+- Wire the `lint-ignore-missing-inline` gate into pre-commit, CI
+  workflow, and `just lint`. The script shipped in v0.23.1; v0.24.0
+  is when it became an enforced gate.
 
 ### Documentation
 
 - `.agent-notes/2026-04-18-ignore-missing-values-helper-consolidation.md`
-  — audit note for the ignoreMissingValueFiles helper refactor that
-  shipped in v0.23.1. Documents the Classification (Convention /
-  uniformity-amplifier), verification performed, and residual risk.
+  — audit note for the ignoreMissingValueFiles helper refactor
+  (Classification: Convention / uniformity-amplifier).
 
 ## [0.23.1] — 2026-04-17
 

--- a/justfile
+++ b/justfile
@@ -16,6 +16,7 @@ lint:
     ./scripts/lint-applicationset-templates.sh
     ./scripts/lint-helm-trim-markers.sh
     ./scripts/lint-ignore-missing-inline.sh
+    ./scripts/lint-pin-git-refs.sh
 
 # Roda todos os pre-commit hooks sobre TODOS os arquivos do repo
 # (útil antes de abrir PR para pegar drift histórico)

--- a/scripts/lint-pin-git-refs.sh
+++ b/scripts/lint-pin-git-refs.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# lint-pin-git-refs.sh
+#
+# Flags `default "X"` fallbacks applied to git references where X is an
+# unpinned name — `HEAD`, `main`, `master`, `latest`. ArgoCD accepts
+# these as valid `targetRevision` / `revision` values, which silently
+# couples the cluster's live state to whatever the upstream branch
+# happens to point at. That coupling defeats:
+#
+#   - Reproducibility: no way to say "this cluster ran chart X at time Y"
+#   - Blast-radius control: a force-push or bad merge rewrites every
+#     cluster that resolved HEAD at that moment
+#   - Audit: compliance reviews cannot pin production to a known-good
+#     artefact
+#
+# Rule: every git reference in an ApplicationSet template must be
+# pinned to a semver tag or a commit SHA. If the upstream may be
+# unset, fail loudly via `required`, not silently via `default "HEAD"`.
+#
+# See: .agent-notes/2026-04-18-pin-git-refs.md
+
+set -euo pipefail
+
+TEMPLATE_DIR="${LINT_TEMPLATE_DIR:-workload-bootstrap/templates}"
+
+if [ ! -d "$TEMPLATE_DIR" ]; then
+    echo "lint-pin-git-refs: directory not found: $TEMPLATE_DIR" >&2
+    exit 2
+fi
+
+exit_code=0
+checked=0
+
+# Match `default "X"` where X is one of the unpinned tokens. Case-
+# sensitive by design — semver tags (v1.2.3) and commit SHAs do not
+# collide with these tokens.
+PATTERN='default[[:space:]]+"(HEAD|main|master|latest)"'
+
+for file in "$TEMPLATE_DIR"/*.yaml "$TEMPLATE_DIR"/*.tpl; do
+    [ -f "$file" ] || continue
+    checked=$((checked + 1))
+
+    violations=$(grep -nE "$PATTERN" "$file" || true)
+
+    if [ -n "$violations" ]; then
+        echo "[FAIL] $file"
+        printf '%s\n' "$violations" | sed 's|^|        unpinned git ref (use `required`, not `default`): |'
+        echo
+        exit_code=1
+    fi
+done
+
+if [ "$exit_code" -eq 0 ]; then
+    echo "lint-pin-git-refs: OK (checked=$checked files)"
+else
+    echo "lint-pin-git-refs: FAIL — see violations above" >&2
+    echo "Reference: .agent-notes/2026-04-18-pin-git-refs.md" >&2
+fi
+
+exit $exit_code

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.24.0
-appVersion: "0.24.0"
+version: 0.24.1
+appVersion: "0.24.1"

--- a/workload-bootstrap/templates/_helpers.tpl
+++ b/workload-bootstrap/templates/_helpers.tpl
@@ -167,7 +167,7 @@ Client GitOps override helpers (ADR 0008 Tier 3).
 {{- define "workload-bootstrap.gitopsSource" -}}
 {{- if and .Values.clientGitopsRepoUrl .Values.deploymentId }}
 - repoURL: {{ .Values.clientGitopsRepoUrl }}
-  targetRevision: {{ .Values.clientGitopsRepoVersion | default "HEAD" }}
+  targetRevision: {{ required "clientGitopsRepoVersion is required when clientGitopsRepoUrl is set" .Values.clientGitopsRepoVersion }}
   ref: gitops
 {{- end }}
 {{- end -}}

--- a/workload-bootstrap/templates/client-apps.yaml
+++ b/workload-bootstrap/templates/client-apps.yaml
@@ -37,7 +37,7 @@ spec:
                   {{- toYaml .Values.clusterSelector.matchLabels | nindent 18 }}
           - git:
               repoURL: {{ .Values.clientGitopsRepoUrl | quote }}
-              revision: {{ .Values.clientGitopsRepoVersion | default "HEAD" | quote }}
+              revision: {{ required "clientGitopsRepoVersion is required when clientGitopsRepoUrl is set" .Values.clientGitopsRepoVersion | quote }}
               directories:
                 - path: "platforms/{{ .Values.deploymentId }}/apps/*"
   template:
@@ -56,7 +56,7 @@ spec:
         #    which ArgoCD applies as raw manifest (the Application itself
         #    references its own Helm chart source).
         - repoURL: {{ .Values.clientGitopsRepoUrl | quote }}
-          targetRevision: {{ .Values.clientGitopsRepoVersion | default "HEAD" | quote }}
+          targetRevision: {{ required "clientGitopsRepoVersion is required when clientGitopsRepoUrl is set" .Values.clientGitopsRepoVersion | quote }}
           path: "{{`{{ .path.path }}`}}"
           directory:
             recurse: false

--- a/workload-bootstrap/templates/client-kyverno-exceptions.yaml
+++ b/workload-bootstrap/templates/client-kyverno-exceptions.yaml
@@ -41,7 +41,7 @@ spec:
       project: workload-baseline
       source:
         repoURL: {{ .Values.clientGitopsRepoUrl | quote }}
-        targetRevision: {{ .Values.clientGitopsRepoVersion | default "HEAD" | quote }}
+        targetRevision: {{ required "clientGitopsRepoVersion is required when clientGitopsRepoUrl is set" .Values.clientGitopsRepoVersion | quote }}
         path: "platforms/{{ .Values.deploymentId }}/policies/exceptions"
         directory:
           recurse: true

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.24.0
+repoVersion: v0.24.1
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
## Summary

Spike 4 under ADR-0015 — elevates the long-standing operator rule *"never `targetRevision: HEAD`"* from operator memory into a mechanical chart contract.

**Classification: Runtime law** (supply-chain material).

## The vulnerability this closes

Four ApplicationSet template locations used `default "HEAD"` as a fallback for `clientGitopsRepoVersion`:

| File | Line |
|---|---|
| `workload-bootstrap/templates/_helpers.tpl` | 170 (gitopsSource helper, inherited by every client-gitops App) |
| `workload-bootstrap/templates/client-kyverno-exceptions.yaml` | 44 |
| `workload-bootstrap/templates/client-apps.yaml` | 40 (generator revision) |
| `workload-bootstrap/templates/client-apps.yaml` | 59 (template source targetRevision) |

Any cluster that set `clientGitopsRepoUrl` without also pinning `clientGitopsRepoVersion` silently tracked `HEAD` — defeating reproducibility, audit, and blast-radius control.

## What this PR does

**Template change** — replace `default "HEAD"` with `required`:

```diff
- targetRevision: {{ .Values.clientGitopsRepoVersion | default "HEAD" | quote }}
+ targetRevision: {{ required "clientGitopsRepoVersion is required when clientGitopsRepoUrl is set" .Values.clientGitopsRepoVersion | quote }}
```

Detection shifts from ArgoCD sync time (silent HEAD) to helm template time (loud render failure).

**New gate** — `scripts/lint-pin-git-refs.sh` flags `default "(HEAD|main|master|latest)"` in templates. Wired into pre-commit, CI, and `just lint`. Fourth parallel lint job.

**Version bump** — v0.24.0 → v0.24.1 (PATCH — bug fix class; hard failure replacing silent failure). Production deployments always pin the version and are unaffected.

**CHANGELOG** — this PR also retroactively documents v0.24.0 entries (dynamic Alloy push URLs, alloy trim marker fix, ignore-missing-inline gate wiring) that were tagged without a CHANGELOG entry at the time. Going forward, every release must move `[Unreleased]` content to a versioned header.

## Validation performed

- `just lint` runs four lints; all pass on this branch
- `./scripts/lint-pin-git-refs.sh` on post-fix HEAD: 20 files checked, 0 violations → exit 0
- Same script against file tree at `main` before spike: correctly flags all four occurrences
- `helm template` with `clientGitopsRepoUrl=X deploymentId=Y` but no `clientGitopsRepoVersion`: fails with `Error: ... clientGitopsRepoVersion is required when clientGitopsRepoUrl is set`
- `helm template` with all three values set: renders 53 `targetRevision` entries cleanly
- `helm template` with none set: client templates gated-off; no `HEAD` in output

## Test plan

- [ ] CI runs all four lint jobs; all pass
- [ ] Local `just lint` reports all four lints OK after merge
- [ ] Tag `v0.24.1` after merge (aligned with Chart.yaml + values.yaml in this PR)

## Framework artefacts

- **Audit note**: `.agent-notes/2026-04-18-pin-git-refs.md` with full Classification table per ADR-0015
- **Memory**: `feedback_pin_all_refs` — the operator rule this spike contractizes (no change needed; the rule now has a gate backing it)
- **Residual risk documented**: gate is scoped to `workload-bootstrap/templates/`. Other repos (estabilis-platform, estabilis-workload) need the same gate installed separately (candidate for follow-up spikes).