### PR TITLE
feat(kyverno-policies): configurable privileged namespace list (v0.26.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,60 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.26.0] — 2026-04-18
+
+### Added
+
+- `components/kyverno-policies` — `policies.inject_pss_labels.privilegedNamespaces`
+  and `.extraPrivilegedNamespaces` values. Platform-managed defaults
+  (`grafana`, `node-exporter`, `trivy-system`) live under
+  `privilegedNamespaces`; downstream overrides append cluster-specific
+  entries via `extraPrivilegedNamespaces` (e.g. `ado-build-agent`,
+  `harbor`, `jfrog-platform`). Helm replaces arrays on merge, so the
+  two-key split keeps platform defaults intact regardless of client
+  overrides.
+
+  The `inject-pss-privileged` rule now iterates the concatenated list,
+  and `inject-pss-baseline-platform` excludes the same list so the two
+  mutation rules never contend for the same namespace.
+
+  Motivation: BuildKit rootless (and similar privileged sidecars)
+  require `seccomp: Unconfined`, which violates PSS `baseline` admission.
+  Previously the privileged list was hardcoded in the template, forcing
+  any new privileged namespace to go through a platform bump.
+
+### Component chart versions
+
+- `components/kyverno-policies`: `0.2.0` → `0.3.0`
+
+### Notes
+
+- Version metadata skips from `0.24.1` directly to `0.26.0` to re-align
+  with the `v0.25.0` git tag, which was pushed without bumping
+  `workload-bootstrap/Chart.yaml` or `workload-bootstrap/values.yaml`
+  (see `[0.25.0]` entry below, added retroactively).
+
+## [0.25.0] — 2026-04-17
+
+> Retroactive entry — the `v0.25.0` tag was pushed without bumping
+> `workload-bootstrap/Chart.yaml` or `workload-bootstrap/values.yaml`
+> at the time. Documented here to keep the changelog consistent with
+> the tag history. `v0.26.0` fixes the metadata drift.
+
+### Added
+
+- `components/argocd-image-updater-base` — base ArgoCD Image Updater
+  configuration (registry list sourced from `global.sharedAcrLoginServer`).
+- `components/acr-image-updater-credentials` — ExternalSecret that
+  mounts the ACR repository-scoped token into the `argocd-image-updater`
+  namespace.
+
+### Fixed
+
+- Remove `estabilis.metadata` from the standalone
+  `acr-image-updater-credentials` component rendering path (chart can
+  now `helm template` without a parent context).
+
 ## [0.24.1] — 2026-04-18
 
 ### Changed

--- a/components/kyverno-policies/Chart.yaml
+++ b/components/kyverno-policies/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: kyverno-policies
 description: Kyverno ClusterPolicies for the Estabilis Platform
 type: application
-version: 0.2.0
+version: 0.3.0

--- a/components/kyverno-policies/templates/inject-pss-labels.yaml
+++ b/components/kyverno-policies/templates/inject-pss-labels.yaml
@@ -11,7 +11,8 @@ metadata:
     policies.kyverno.io/description: >-
       Injects Pod Security Standards (PSS) labels on namespaces.
       Client namespaces (app-*) get enforce=restricted.
-      Privileged namespaces (node-exporter, trivy-system) get enforce=privileged.
+      Namespaces listed in .Values.policies.inject_pss_labels.privilegedNamespaces
+      and .extraPrivilegedNamespaces get enforce=privileged.
       All other platform namespaces get enforce=baseline with warn/audit=restricted.
 spec:
   background: true
@@ -41,9 +42,9 @@ spec:
               kinds:
                 - Namespace
               names:
-                - grafana
-                - node-exporter
-                - trivy-system
+{{- range (concat (default (list) .Values.policies.inject_pss_labels.privilegedNamespaces) (default (list) .Values.policies.inject_pss_labels.extraPrivilegedNamespaces)) }}
+                - {{ . }}
+{{- end }}
       mutate:
         patchStrategicMerge:
           metadata:
@@ -65,8 +66,9 @@ spec:
           - resources:
               names:
                 - "app-*"
-                - node-exporter
-                - trivy-system
+{{- range (concat (default (list) .Values.policies.inject_pss_labels.privilegedNamespaces) (default (list) .Values.policies.inject_pss_labels.extraPrivilegedNamespaces)) }}
+                - {{ . }}
+{{- end }}
           - resources:
               names:
 {{ include "kyverno-policies.excluded-namespace-list" . }}

--- a/components/kyverno-policies/values.yaml
+++ b/components/kyverno-policies/values.yaml
@@ -68,6 +68,20 @@ policies:
     enabled: true
   inject_pss_labels:
     enabled: true
+    # Namespaces that receive pod-security.kubernetes.io/enforce=privileged
+    # (plus warn/audit=baseline). Platform-managed defaults — do not
+    # override from downstream; clients extending this list should use
+    # extraPrivilegedNamespaces instead (Helm merges scalars but REPLACES
+    # arrays, so splitting the list in two keeps the platform defaults
+    # intact regardless of client overrides).
+    privilegedNamespaces:
+      - grafana
+      - node-exporter
+      - trivy-system
+    # Client-extensible privileged namespaces. Default empty; downstream
+    # overrides append cluster-specific entries here
+    # (e.g. ado-build-agent, harbor, jfrog-platform).
+    extraPrivilegedNamespaces: []
   inject_security_context:
     enabled: true
   no_latest_tag:

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.24.1
-appVersion: "0.24.1"
+version: 0.26.0
+appVersion: "0.26.0"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.24.1
+repoVersion: v0.26.0
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
## Summary

- Expose `policies.inject_pss_labels.privilegedNamespaces` (platform-managed defaults) and `.extraPrivilegedNamespaces` (client-extensible) in `components/kyverno-policies`. Defaults preserve current behavior (`grafana`, `node-exporter`, `trivy-system`).
- Template now iterates the concatenated list in both the `inject-pss-privileged` mutation rule AND the `inject-pss-baseline-platform` exclude list — so the two rules never contend for the same namespace.
- Bump `workload-bootstrap/Chart.yaml` + `values.yaml` + component chart. Version metadata jumps `0.24.1 → 0.26.0` to re-align with the orphan `v0.25.0` tag; `[0.25.0]` documented retroactively in CHANGELOG.

## Motivation

`inject-pss-labels` hardcoded the privileged namespace set inside the template. Any new namespace needing `enforce=privileged` (e.g. BuildKit rootless sidecars for CI runners) required a platform-level bump — no per-client override path.

Concrete trigger: an ADO build agent with BuildKit rootless requires `seccomp: Unconfined`, which violates PSS `baseline`. The Kyverno mutation policy was racing against ArgoCD's `managedNamespaceMetadata`, forcing the namespace back to `baseline` and blocking the sidecar. Clients can now extend the privileged list via downstream values.

## Backward compatibility

`helm template` with defaults renders the exact same list (`grafana, node-exporter, trivy-system`) as before the change. No behavior change for existing deployments.

## Test plan

- [x] `just lint` — all four scripts pass
- [x] `helm template` renders both kyverno-policies component and workload-bootstrap chart
- [x] Verify rendered output matches previous hardcode with default values
- [x] Verify `--set extraPrivilegedNamespaces={ado-build-agent,harbor}` appends correctly to both privileged match AND baseline exclude lists
- [ ] After merge + tag `v0.26.0`: downstream wrapper override to be validated end-to-end