### PR TITLE
fix(argocd-image-updater): revert config.log.level → config.logLevel (v0.x schema)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.26.1] — 2026-04-21
+
+### Fixed — `argocd-image-updater` values schema reverted to v0.x keys
+
+`values/platform/argocd-image-updater.yaml` used `config.log.level`
+(dotted key, v1.x chart schema). Paired commit in `estabilis-platform`
+v0.12.2 pins the chart to `0.14.0` (app v0.17.0, annotation-based),
+which expects `config.logLevel` (camelCase). Reverted the key.
+
+No behavior change on a running cluster — the ConfigMap values are
+equivalent at runtime.
+
+Paired change with **estabilis-platform v0.12.2**. See
+`estabilis-platform-tools/docs/adr/0019-argocd-image-updater-v0x-correction.md`
+for the full postmortem.
+
 ## [0.26.0] — 2026-04-18
 
 ### Added

--- a/values/platform/argocd-image-updater.yaml
+++ b/values/platform/argocd-image-updater.yaml
@@ -29,7 +29,10 @@ resources:
     memory: 256Mi
 
 config:
-  log.level: info
+  # Chart v0.x key. In v1.x this was renamed to `log.level` (dotted).
+  # We're pinned to chart 0.14.0 (app v0.17.0, annotation-based track)
+  # — see platform-root/templates/argocd-image-updater.yaml for rationale.
+  logLevel: info
   # Registries configured by downstream override — each client defines
   # their own ACR/registry + credentials reference.
   registries: []

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.26.0
-appVersion: "0.26.0"
+version: 0.26.1
+appVersion: "0.26.1"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.26.0
+repoVersion: v0.26.1
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
Paired with [Estabilis/estabilis-platform#62](https://github.com/Estabilis/estabilis-platform/pull/62).

## Change

`values/platform/argocd-image-updater.yaml` used `config.log.level` (v1.x chart schema). The paired platform PR pins the chart to `0.14.0` (app v0.17.0, annotation-based), which expects `config.logLevel` (camelCase).

## Why

The upstream `argocd-image-updater` v1.0.0 release (2025-11-11) was a rewrite to CRD-only — annotations on ArgoCD Applications are no longer read. Our write-back design (ADR 0016 D3) depends on those annotations. Downgrading to the v0.x track restores the contract.

Full postmortem: **estabilis-platform-tools ADR 0019** (separate PR).

## Version bumps (per cross-repo versioning rules)

- `workload-bootstrap/Chart.yaml` `version` + `appVersion` → `0.26.1`
- `workload-bootstrap/values.yaml` `repoVersion` → `v0.26.1`
- Tag `v0.26.1` after merge

## Ordering

1. This PR + platform PR #62 merge (can be in any order)
2. Tag both repos (v0.26.1 here, v0.12.2 in platform)
3. Bump downstream template `estabilis-platform-downstream` (`overrides/platform-root/values.yaml` `platformGitopsVersion` → `v0.26.1`; `main.tf` ref → `v0.12.2`)
4. Bump client downstream `transfero-platform-azure-eastus2-hml`
5. `terraform init -upgrade && apply` on the client → `estabilis promote`