### PR TITLE
feat(acr-image-updater-credentials): emit ArgoCD repo-creds for shared ACR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,39 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.27.0] — 2026-04-21
+
+### Added — `acr-image-updater-credentials` emits ArgoCD repo-creds
+
+The `acr-image-updater-credentials` component (v0.1.0 → v0.2.0) now
+creates **two** ExternalSecrets from the same Key Vault token:
+
+1. `acr-image-updater-credentials` (existing) — docker config for
+   ArgoCD Image Updater's registry pulls.
+2. `cred-acr-shared-charts` (new) — ArgoCD repo-creds so the
+   **repo-server** can pull OCI Helm charts from the same ACR.
+
+Rationale: deployments that publish Helm charts to the same shared
+ACR that Image Updater watches (e.g., Transfero HML publishing
+`common-app` to `acrtransferosharedhml`) need ArgoCD to authenticate
+OCI chart pulls. Without this second Secret, chart pulls fail with
+`401 unauthorized` (observed 2026-04-21 on partner-service-hml).
+
+Always rendered alongside (1) when `acrLoginServer` is set — harmless
+when no Application pulls charts from this host. Opt-out is not
+exposed: the incremental runtime cost (one K8s Secret, same KV lookup)
+does not justify the configuration surface.
+
+No consumer-side change required. Deployments with `sharedAcrLoginServer`
+set in their platform-root override get the new Secret automatically
+on next sync.
+
+Paired with:
+- `estabilis-platform` no change (template passes `acrLoginServer`,
+  which is already wired).
+- Downstream `transfero-platform-azure-eastus2-hml` bumps
+  `platformGitopsVersion` to v0.27.0 — propagates the new Secret.
+
 ## [0.26.1] — 2026-04-21
 
 ### Fixed — `argocd-image-updater` values schema reverted to v0.x keys

--- a/components/acr-image-updater-credentials/Chart.yaml
+++ b/components/acr-image-updater-credentials/Chart.yaml
@@ -1,8 +1,11 @@
 apiVersion: v2
 name: acr-image-updater-credentials
 description: |
-  ExternalSecret that reads ACR repository-scoped token from Key Vault
-  and creates a docker config JSON Secret for ArgoCD Image Updater.
+  ExternalSecrets that read an ACR repository-scoped token from Key Vault
+  and create:
+    1. A docker-config JSON Secret for ArgoCD Image Updater.
+    2. (Opt-in via repoCreds.enabled) An ArgoCD repo-creds Secret so the
+       ArgoCD repo-server can pull OCI Helm charts from the same registry.
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"

--- a/components/acr-image-updater-credentials/templates/external-secret.yaml
+++ b/components/acr-image-updater-credentials/templates/external-secret.yaml
@@ -1,4 +1,9 @@
 {{- if .Values.acrLoginServer }}
+# --------------------------------------------------------------------
+# 1) Docker config Secret — consumed by ArgoCD Image Updater's
+#    `registries.conf` via `pullsecret:argocd/acr-image-updater-credentials`.
+#    Format is fixed by Image Updater (docker `auths:` structure).
+# --------------------------------------------------------------------
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -19,6 +24,50 @@ spec:
       type: kubernetes.io/dockerconfigjson
       data:
         .dockerconfigjson: '{"auths":{"{{ .Values.acrLoginServer }}":{"username":"{{ .Values.acrTokenUsername }}","password":"{{ "{{ .acrToken }}" }}"}}}'
+  data:
+    - secretKey: acrToken
+      remoteRef:
+        key: {{ .Values.kvSecretName }}
+---
+# --------------------------------------------------------------------
+# 2) ArgoCD repo-creds Secret — consumed by ArgoCD repo-server when
+#    pulling Helm charts from OCI registries (e.g. the shared ACR that
+#    hosts `common-app`). Label-driven convention: `type: helm` +
+#    `enableOCI: "true"` + registry host in `url`.
+#
+#    Same source token as (1) — different output format to satisfy a
+#    different consumer. Always rendered alongside (1): the repo-server
+#    only uses this credential when an Application actually pulls a
+#    chart from this host, so it is harmless for deployments that only
+#    consume images (not charts) from this ACR.
+# --------------------------------------------------------------------
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.repoCreds.secretName }}
+  labels:
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: estabilis-platform
+    estabilis.io/component: acr-image-updater-credentials
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: platform-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: {{ .Values.repoCreds.secretName }}
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: repo-creds
+      data:
+        type: helm
+        url: {{ .Values.acrLoginServer }}
+        enableOCI: "true"
+        username: {{ .Values.acrTokenUsername }}
+        password: '{{ "{{ .acrToken }}" }}'
   data:
     - secretKey: acrToken
       remoteRef:

--- a/components/acr-image-updater-credentials/values.yaml
+++ b/components/acr-image-updater-credentials/values.yaml
@@ -9,3 +9,9 @@ kvSecretName: "acr-shared-token"
 # Username for the repository-scoped token.
 # Convention: same name as the token resource in Azure.
 acrTokenUsername: "acr-token"
+
+# ArgoCD repo-creds Secret name — consumed by `argocd` repo-server to
+# pull OCI Helm charts from this same ACR. Always rendered when
+# `acrLoginServer` is set; harmless if no Application pulls charts.
+repoCreds:
+  secretName: "cred-acr-shared-charts"

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.26.1
-appVersion: "0.26.1"
+version: 0.27.0
+appVersion: "0.27.0"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.26.1
+repoVersion: v0.27.0
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
## Problem

After restoring Image Updater v0.x (ADR 0019), the next blocker on partner-service-hml deploy surfaced: ArgoCD repo-server hits 401 pulling the `common-app` Helm chart from `acrtransferosharedhml.azurecr.io`:

```
error pulling OCI chart: helm pull oci://acrtransferosharedhml.azurecr.io/charts/common-app --version 0.1.0-alpha.2
→ 401 unauthorized: authentication required
```

Context: the `transfero-acr-shared-hml` Terraform already creates a repository-scoped pull token (`acr-shared-token` in `kv-transfero-hml-lmj060`). The `acr-image-updater-credentials` component already consumes this token to create a docker-config Secret for Image Updater. **ArgoCD repo-server uses a different Secret format** (`repo-creds` label + `type: helm` + `enableOCI: true`) — that Secret didn't exist.

## Fix

Extend the component template to emit **both** Secrets from the same KV token:

| Secret | Format | Consumer |
|---|---|---|
| `acr-image-updater-credentials` (existing) | `kubernetes.io/dockerconfigjson` | Image Updater `registries.conf` |
| `cred-acr-shared-charts` (new) | `Opaque` + label `argocd.argoproj.io/secret-type=repo-creds` | ArgoCD repo-server |

No consumer-side change required. Always rendered when `acrLoginServer` is set — no opt-out flag, because the incremental cost (one extra K8s Secret from the same KV secret) does not justify the config surface.

## Version bumps

Per CLAUDE.md versioning rules (new feature = MINOR):
- `components/acr-image-updater-credentials/Chart.yaml` `0.1.0` → `0.2.0`
- `workload-bootstrap/Chart.yaml` `version` + `appVersion` `0.26.1` → `0.27.0`
- `workload-bootstrap/values.yaml` `repoVersion` `v0.26.1` → `v0.27.0`
- Tag `v0.27.0` after merge

## Downstream propagation

1. Tag `v0.27.0` here
2. Bump client `transfero-platform-azure-eastus2-hml` (`platformGitopsVersion` `v0.26.1` → `v0.27.0`, then `v1.0.74`)
3. Operator `terraform apply` → platform-root syncs → new Secret appears in `argocd` namespace
4. ArgoCD repo-server detects repo-creds → OCI pull of `common-app` succeeds
5. partner-service-hml renders → Image Updater picks up image annotations → write-back PR opens

## Risk

Low. The new Secret is additive; if no Application pulls from the shared ACR, the Secret sits unused. The existing `acr-image-updater-credentials` dockerconfig Secret is unchanged — Image Updater continues working as before.