### PR TITLE
fix(acr-image-updater-credentials): acrTokenUsername default acr-token → image-updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.27.1] — 2026-04-21
+
+### Fixed — `acrTokenUsername` default now matches Terraform token name
+
+`components/acr-image-updater-credentials/values.yaml` defaulted
+`acrTokenUsername` to `"acr-token"` — but the token resource created
+by `transfero-acr-shared-hml` Terraform is `name = "image-updater"`.
+ACR login uses the token *resource name* as the username; the old
+default returned `401 unauthorized`.
+
+Verified 2026-04-21 from inside `argocd-repo-server`:
+- `helm registry login -u acr-token` → `401`
+- `helm registry login -u image-updater` → `Login Succeeded` + chart
+  pulled.
+
+This bug was invisible until v0.27.0 began exercising the credential
+(the repo-server only calls it when an Application pulls from the
+shared ACR). Image Updater has the same bug in its docker-config
+Secret but was never observed failing because no image pull had
+been attempted since the v0.x restore (ADR 0019).
+
+Patch-level bump; no API surface change. Downstream deployments pick
+up the fix automatically after `terraform apply` + promote.
+
 ## [0.27.0] — 2026-04-21
 
 ### Added — `acr-image-updater-credentials` emits ArgoCD repo-creds

--- a/components/acr-image-updater-credentials/Chart.yaml
+++ b/components/acr-image-updater-credentials/Chart.yaml
@@ -7,5 +7,5 @@ description: |
     2. (Opt-in via repoCreds.enabled) An ArgoCD repo-creds Secret so the
        ArgoCD repo-server can pull OCI Helm charts from the same registry.
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.2.1
+appVersion: "0.2.1"

--- a/components/acr-image-updater-credentials/values.yaml
+++ b/components/acr-image-updater-credentials/values.yaml
@@ -7,8 +7,13 @@ acrLoginServer: ""
 kvSecretName: "acr-shared-token"
 
 # Username for the repository-scoped token.
-# Convention: same name as the token resource in Azure.
-acrTokenUsername: "acr-token"
+# Convention: the ACR `token` resource name in Azure. The token resource
+# in `transfero-acr-shared-hml` Terraform is created with
+# `name = "image-updater"` — ACR login expects that name as the username
+# (verified 2026-04-21: username `acr-token` returns 401, `image-updater`
+# authenticates). Downstream overrides this only if a different token
+# resource is used.
+acrTokenUsername: "image-updater"
 
 # ArgoCD repo-creds Secret name — consumed by `argocd` repo-server to
 # pull OCI Helm charts from this same ACR. Always rendered when

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.27.0
-appVersion: "0.27.0"
+version: 0.27.1
+appVersion: "0.27.1"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.27.0
+repoVersion: v0.27.1
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
## Problem

After v0.27.0 started exercising the shared ACR credential (new ArgoCD repo-creds Secret), chart pulls returned `401 unauthorized` from within `argocd-repo-server`:

```
helm pull oci://acrtransferosharedhml.azurecr.io/charts/common-app --version 0.1.0-alpha.2
→ 401 unauthorized
```

## Root cause

The default `acrTokenUsername: "acr-token"` didn't match the actual ACR token resource name. The terraform in `transfero-acr-shared-hml` creates the token with:

```hcl
resource "azurerm_container_registry_token" "image_updater" {
  name = "image-updater"
  ...
}
```

ACR login uses the **token resource name** as the username. `acr-token` was dead code.

## Verification

From inside `argocd-repo-server` pod, with the same password from KV:

| Username | Result |
|---|---|
| `acr-token` | `401 unauthorized` |
| `image-updater` | `Login Succeeded` + chart pull success |

## Fix

`components/acr-image-updater-credentials/values.yaml` → `acrTokenUsername: "image-updater"`.

Both rendered Secrets (Image Updater docker config + ArgoCD repo-creds) use this same username, so the single-line change fixes both consumers.

## Why this wasn't caught sooner

Image Updater had the same wrong username in its docker-config Secret since v0.1.0 of the component, but the bug was invisible — v1.x image-updater was reading no annotations (ADR 0019), so it never attempted a pull. v0.x image-updater started at 21:04 and has been running 2-minute cycles, but all have been 'No supported source type' skips — no pull ever attempted.

v0.27.0 (this PR's parent) finally made the bug observable by adding a repo-creds Secret that ArgoCD repo-server actually exercises.

## Bumps

- `components/acr-image-updater-credentials/Chart.yaml` v0.2.0 → v0.2.1
- `workload-bootstrap/Chart.yaml` version + appVersion → 0.27.1
- `workload-bootstrap/values.yaml` repoVersion → v0.27.1
- Tag `v0.27.1` after merge

## Downstream

Client bump `platformGitopsVersion` v0.27.0 → v0.27.1 + new client tag v1.0.75 + terraform apply + promote. Secret content updates in-place, no pod restart needed.