### PR TITLE
fix(acr-image-updater-credentials): dockerconfig uses auth field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.27.2] — 2026-04-21
+
+### Fixed — `acr-image-updater-credentials` dockerconfig uses `auth` field
+
+The docker-config Secret was generated with `username` + `password` fields:
+
+```json
+{"auths":{"<host>":{"username":"<u>","password":"<p>"}}}
+```
+
+Image Updater v0.17 expects the `auth` field (base64 of `u:p`) and errors:
+
+```
+Could not set registry endpoint credentials: invalid auth token for
+registry entry <host> ('auth' should be string')
+```
+
+Switched the ExternalSecret template to compute `auth` at render time via
+sprig `b64enc`. The ArgoCD repo-server credential Secret already works
+with `username` + `password` fields and is unchanged.
+
+Component v0.2.1 → v0.2.2 (patch).
+
 ## [0.27.1] — 2026-04-21
 
 ### Fixed — `acrTokenUsername` default now matches Terraform token name

--- a/components/acr-image-updater-credentials/Chart.yaml
+++ b/components/acr-image-updater-credentials/Chart.yaml
@@ -7,5 +7,5 @@ description: |
     2. (Opt-in via repoCreds.enabled) An ArgoCD repo-creds Secret so the
        ArgoCD repo-server can pull OCI Helm charts from the same registry.
 type: application
-version: 0.2.1
-appVersion: "0.2.1"
+version: 0.2.2
+appVersion: "0.2.2"

--- a/components/acr-image-updater-credentials/templates/external-secret.yaml
+++ b/components/acr-image-updater-credentials/templates/external-secret.yaml
@@ -21,9 +21,16 @@ spec:
     name: acr-image-updater-credentials
     creationPolicy: Owner
     template:
+      engineVersion: v2
       type: kubernetes.io/dockerconfigjson
       data:
-        .dockerconfigjson: '{"auths":{"{{ .Values.acrLoginServer }}":{"username":"{{ .Values.acrTokenUsername }}","password":"{{ "{{ .acrToken }}" }}"}}}'
+        # Image Updater v0.x parses `.auth` as base64(username:password) and
+        # errors with `'auth' should be string` if only username+password are
+        # present. Compute auth via the ExternalSecret Go template (sprig
+        # `b64enc`). The Helm render emits the literal Go-template
+        # expression; ExternalSecret evaluates it using `.acrToken` from the
+        # Key Vault.
+        .dockerconfigjson: '{"auths":{"{{ .Values.acrLoginServer }}":{"auth":"{{ printf "{{ printf %q .acrToken | b64enc }}" (printf "%s:%%s" .Values.acrTokenUsername) }}"}}}'
   data:
     - secretKey: acrToken
       remoteRef:

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.27.1
-appVersion: "0.27.1"
+version: 0.27.2
+appVersion: "0.27.2"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.27.1
+repoVersion: v0.27.2
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
## Problem

After v0.27.1 restored Image Updater + correct ACR username, the next error surfaced in the Image Updater controller logs:

```
error="Could not set registry endpoint credentials: invalid auth token for 
registry entry acrtransferosharedhml.azurecr.io ('auth' should be string')"
```

## Root cause

Image Updater v0.17 parses `.dockerconfigjson` expecting the `auth` field (base64 of `username:password`). Our template was emitting separate `username` + `password` fields — a valid K8s dockerconfig format accepted by docker/helm but not by the image-updater library version we're on.

## Fix

Generate `auth` field via ExternalSecret Go-template engine v2 (sprig `b64enc`):

- Before: `{"auths":{"<host>":{"username":"<u>","password":"<p>"}}}`
- After: `{"auths":{"<host>":{"auth":"<b64(u:p)>"}}}`

The ArgoCD repo-creds Secret (separate ExternalSecret in the same template) was NOT affected — it already used separate `username` + `password` fields, which is the correct format for `argocd.argoproj.io/secret-type=repo-creds`.

## Bumps

- `components/acr-image-updater-credentials` v0.2.1 → v0.2.2
- `workload-bootstrap/Chart.yaml` + values → v0.27.2

## Downstream

Client bump `platformGitopsVersion` v0.27.1 → v0.27.2, client v1.0.77. Secret in-place replace; no pod restart needed.