### PR TITLE
feat(acr-image-updater-credentials): SP auth mode (AcrPull RBAC) — default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.28.0] — 2026-04-21
+
+### Changed — `acr-image-updater-credentials` credential mode defaults to SP
+
+The component now supports two credential modes for the shared ACR:
+
+- **`sp` (default)** — Azure AD Service Principal with `AcrPull` RBAC.
+  ExternalSecret reads `(clientId, clientSecret)` from two KV secrets
+  and renders both the docker-config (`auth: base64(clientId:clientSecret)`)
+  and the repo-creds Secret (`username: clientId` + `password: clientSecret`).
+- **`token` (legacy)** — scope-map token + fixed username. Retained for
+  rollback; NOT recommended because ArgoCD Image Updater asks for the
+  standard Docker Registry `:pull` scope which maps only to `content/read`
+  under ACR scope-maps. Listing tags (`/v2/<repo>/tags/list`) needs
+  `metadata/read`, so the legacy path returns 401 on tag listing even
+  when the scope-map grants both actions.
+
+The SP path sidesteps the scope issue entirely: ACR resolves the AAD
+identity's RBAC role and issues access tokens covering the full pull
+surface without client-side scope negotiation.
+
+Requires the paired Terraform change in `transfero-acr-shared-hml`
+(new `image_updater_sp_enabled` variable, creates the SP + RBAC +
+KV secrets). See ADR follow-up / commit message in that repo for
+details.
+
 ## [0.27.2] — 2026-04-21
 
 ### Fixed — `acr-image-updater-credentials` dockerconfig uses `auth` field

--- a/components/acr-image-updater-credentials/Chart.yaml
+++ b/components/acr-image-updater-credentials/Chart.yaml
@@ -1,11 +1,17 @@
 apiVersion: v2
 name: acr-image-updater-credentials
 description: |
-  ExternalSecrets that read an ACR repository-scoped token from Key Vault
-  and create:
+  ExternalSecrets that read ACR credentials from Key Vault and render
+  two Kubernetes Secrets:
     1. A docker-config JSON Secret for ArgoCD Image Updater.
-    2. (Opt-in via repoCreds.enabled) An ArgoCD repo-creds Secret so the
-       ArgoCD repo-server can pull OCI Helm charts from the same registry.
+    2. An ArgoCD repo-creds Secret so the repo-server can pull OCI
+       Helm charts from the same registry.
+
+  Supports two credential modes:
+    - sp (default) — Azure AD Service Principal with AcrPull RBAC.
+      Preferred: tag listing works (AAD auth skips scope-map scope
+      negotiation).
+    - token — legacy repository-scoped token. Kept for rollback.
 type: application
-version: 0.2.2
-appVersion: "0.2.2"
+version: 0.3.0
+appVersion: "0.3.0"

--- a/components/acr-image-updater-credentials/templates/external-secret.yaml
+++ b/components/acr-image-updater-credentials/templates/external-secret.yaml
@@ -1,8 +1,30 @@
 {{- if .Values.acrLoginServer }}
+{{- /*
+  Render two ExternalSecrets, each backed by the SAME Key Vault source
+  material but shaped for a different consumer:
+
+    1) acr-image-updater-credentials  (kubernetes.io/dockerconfigjson)
+       → read by ArgoCD Image Updater via `pullsecret:` reference.
+    2) <repoCreds.secretName>         (Opaque + repo-creds label)
+       → read by ArgoCD repo-server for OCI Helm pulls.
+
+  Credential source switches on `.Values.credentialMode`:
+
+    sp    — Azure AD Service Principal (clientId, clientSecret) with
+            AcrPull RBAC role. Preferred. Tag listing works because
+            AAD auth skips scope-map negotiation.
+    token — legacy scope-map token (password only, fixed username).
+            Retained for rollback.
+*/ -}}
+{{- $mode := .Values.credentialMode | default "sp" -}}
+{{- if not (or (eq $mode "sp") (eq $mode "token")) }}
+{{- fail (printf "credentialMode must be 'sp' or 'token', got %q" $mode) }}
+{{- end }}
 # --------------------------------------------------------------------
 # 1) Docker config Secret — consumed by ArgoCD Image Updater's
 #    `registries.conf` via `pullsecret:argocd/acr-image-updater-credentials`.
-#    Format is fixed by Image Updater (docker `auths:` structure).
+#    Format is fixed by Image Updater (docker `auths:` structure with
+#    `.auth` = base64(username:password)).
 # --------------------------------------------------------------------
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -24,29 +46,30 @@ spec:
       engineVersion: v2
       type: kubernetes.io/dockerconfigjson
       data:
-        # Image Updater v0.x parses `.auth` as base64(username:password) and
-        # errors with `'auth' should be string` if only username+password are
-        # present. Compute auth via the ExternalSecret Go template (sprig
-        # `b64enc`). The Helm render emits the literal Go-template
-        # expression; ExternalSecret evaluates it using `.acrToken` from the
-        # Key Vault.
-        .dockerconfigjson: '{"auths":{"{{ .Values.acrLoginServer }}":{"auth":"{{ printf "{{ printf %q .acrToken | b64enc }}" (printf "%s:%%s" .Values.acrTokenUsername) }}"}}}'
+        {{- if eq $mode "sp" }}
+        .dockerconfigjson: '{"auths":{"{{ .Values.acrLoginServer }}":{"auth":"{{ "{{" }} printf "%s:%s" .clientId .clientSecret | b64enc {{ "}}" }}"}}}'
+        {{- else }}
+        .dockerconfigjson: '{"auths":{"{{ .Values.acrLoginServer }}":{"auth":"{{ printf "{{ printf %q .token | b64enc }}" (printf "%s:%%s" .Values.token.username) }}"}}}'
+        {{- end }}
   data:
-    - secretKey: acrToken
+    {{- if eq $mode "sp" }}
+    - secretKey: clientId
       remoteRef:
-        key: {{ .Values.kvSecretName }}
+        key: {{ .Values.sp.kvClientIdSecret }}
+    - secretKey: clientSecret
+      remoteRef:
+        key: {{ .Values.sp.kvClientSecretSecret }}
+    {{- else }}
+    - secretKey: token
+      remoteRef:
+        key: {{ .Values.token.kvSecretName }}
+    {{- end }}
 ---
 # --------------------------------------------------------------------
 # 2) ArgoCD repo-creds Secret — consumed by ArgoCD repo-server when
 #    pulling Helm charts from OCI registries (e.g. the shared ACR that
 #    hosts `common-app`). Label-driven convention: `type: helm` +
 #    `enableOCI: "true"` + registry host in `url`.
-#
-#    Same source token as (1) — different output format to satisfy a
-#    different consumer. Always rendered alongside (1): the repo-server
-#    only uses this credential when an Application actually pulls a
-#    chart from this host, so it is harmless for deployments that only
-#    consume images (not charts) from this ACR.
 # --------------------------------------------------------------------
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -65,6 +88,7 @@ spec:
     name: {{ .Values.repoCreds.secretName }}
     creationPolicy: Owner
     template:
+      engineVersion: v2
       type: Opaque
       metadata:
         labels:
@@ -73,10 +97,24 @@ spec:
         type: helm
         url: {{ .Values.acrLoginServer }}
         enableOCI: "true"
-        username: {{ .Values.acrTokenUsername }}
-        password: '{{ "{{ .acrToken }}" }}'
+        {{- if eq $mode "sp" }}
+        username: '{{ "{{ .clientId }}" }}'
+        password: '{{ "{{ .clientSecret }}" }}'
+        {{- else }}
+        username: {{ .Values.token.username | quote }}
+        password: '{{ "{{ .token }}" }}'
+        {{- end }}
   data:
-    - secretKey: acrToken
+    {{- if eq $mode "sp" }}
+    - secretKey: clientId
       remoteRef:
-        key: {{ .Values.kvSecretName }}
+        key: {{ .Values.sp.kvClientIdSecret }}
+    - secretKey: clientSecret
+      remoteRef:
+        key: {{ .Values.sp.kvClientSecretSecret }}
+    {{- else }}
+    - secretKey: token
+      remoteRef:
+        key: {{ .Values.token.kvSecretName }}
+    {{- end }}
 {{- end }}

--- a/components/acr-image-updater-credentials/values.yaml
+++ b/components/acr-image-updater-credentials/values.yaml
@@ -2,21 +2,43 @@
 # global.sharedAcrLoginServer (Terraform → ConfigMap → helm parameter).
 acrLoginServer: ""
 
-# Key Vault secret name containing the ACR repository-scoped token password.
-# Created by the ACR shared downstream Terraform.
-kvSecretName: "acr-shared-token"
+# -----------------------------------------------------------------------------
+# Credential source — two modes
+# -----------------------------------------------------------------------------
+# The component supports either:
+#
+# 1) Azure AD Service Principal (preferred) — `credentialMode: sp`
+#    Reads two KV secrets (client_id, client_secret). The SP has `AcrPull`
+#    RBAC role on the registry. ACR resolves the AAD identity and issues
+#    access tokens covering the full pull surface (content/read AND
+#    metadata/read) in a single call. Tag listing (`/v2/<repo>/tags/list`)
+#    works because the AAD path doesn't rely on the client requesting
+#    non-standard scopes — it uses Azure RBAC directly.
+#
+# 2) Repository-scoped token (legacy) — `credentialMode: token`
+#    Reads ONE KV secret (the token password) and pairs it with a fixed
+#    username. ACR scope-map tokens grant actions matching the exact
+#    scope requested; Image Updater asks `:pull` and receives a token
+#    with only `content/read`, so `tags/list` returns 401 because listing
+#    tags requires `metadata/read`. Kept as a rollback path.
+#
+# Defaults to `sp` because tag listing must work for Image Updater.
 
-# Username for the repository-scoped token.
-# Convention: the ACR `token` resource name in Azure. The token resource
-# in `transfero-acr-shared-hml` Terraform is created with
-# `name = "image-updater"` — ACR login expects that name as the username
-# (verified 2026-04-21: username `acr-token` returns 401, `image-updater`
-# authenticates). Downstream overrides this only if a different token
-# resource is used.
-acrTokenUsername: "image-updater"
+credentialMode: sp
+
+# Service Principal mode — two KV secrets populated by the
+# `transfero-acr-shared-hml` Terraform when `image_updater_sp_enabled = true`.
+sp:
+  kvClientIdSecret: acr-shared-sp-client-id
+  kvClientSecretSecret: acr-shared-sp-client-secret
+
+# Token mode — legacy path, kept for rollback.
+token:
+  kvSecretName: acr-shared-token
+  username: image-updater
 
 # ArgoCD repo-creds Secret name — consumed by `argocd` repo-server to
 # pull OCI Helm charts from this same ACR. Always rendered when
 # `acrLoginServer` is set; harmless if no Application pulls charts.
 repoCreds:
-  secretName: "cred-acr-shared-charts"
+  secretName: cred-acr-shared-charts

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.27.2
-appVersion: "0.27.2"
+version: 0.28.0
+appVersion: "0.28.0"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.27.2
+repoVersion: v0.28.0
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
## Problem

ArgoCD Image Updater v0.x cannot list tags from `acrtransferosharedhml` even though the scope-map grants both `content/read` and `metadata/read`:

```
Could not get tags from registry: errors:
denied: requested access to the resource is denied
unauthorized: authentication required
```

**Root cause (proven via manual OAuth token inspection):**

| Scope asked | JWT actions granted | `/v2/<repo>/tags/list` |
|---|---|---|
| `repository:X:pull` | `["pull"]` | 401 |
| `repository:X:metadata_read` | `["metadata_read"]` | ✅ 200 |
| `repository:X:*` | `["pull","metadata_read"]` | ✅ 200 |

Image Updater follows the Docker Registry convention and asks `:pull`. ACR scope-map tokens honor the exact scope requested — `:pull` maps to `content/read` only, not both actions. Tag listing requires `metadata/read`, so the path 401s and the write-back loop cannot proceed.

## Fix

Azure AD Service Principal with `AcrPull` RBAC role. When a client presents SP credentials to ACR, ACR resolves the RBAC assignment server-side and issues an access token covering the full `AcrPull` surface (content + metadata + blobs) from a single exchange. No client-side scope negotiation needed.

- `components/acr-image-updater-credentials/values.yaml` — new `credentialMode` (default `sp`, legacy `token` kept for rollback)
- `components/acr-image-updater-credentials/templates/external-secret.yaml` — rendered dockerconfig uses `auth: base64(clientId:clientSecret)`; repo-creds uses `username: <clientId>` + `password: <clientSecret>`
- `components/.../Chart.yaml` 0.2.2 → 0.3.0 (minor — new feature)
- `workload-bootstrap/Chart.yaml` + `values.yaml` 0.27.2 → 0.28.0

## Paired Terraform (not in this PR)

`transfero-acr-shared-hml` gets two new variables:

```hcl
image_updater_sp_enabled = true
image_updater_sp_password_end_date_relative = "17520h"  # 2 years
```

Creates the AAD application + service principal, assigns `AcrPull`, stores `(clientId, clientSecret)` in the platform Key Vault as `acr-shared-sp-client-id` and `acr-shared-sp-client-secret`.

The existing scope-map token is retained as `image_updater_token_enabled = true` for rollback; flip `credentialMode: token` in the chart overlay to revert without state changes.

## Downstream

1. User runs `terraform apply` in the shared ACR repo — creates SP + KV secrets
2. Merge this PR → tag v0.28.0
3. Bump client downstream `platformGitopsVersion: v0.27.2 → v0.28.0` → tag v1.0.80
4. Operator edits tfvars + terraform apply + promote
5. Image Updater authenticates via SP → tag listing succeeds → write-back PR opens on transfero-gitops with real image tag + digest