### PR TITLE
feat(acr-image-updater-credentials): git write-back PAT Secret (v0.29.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,36 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.29.0] — 2026-04-22
+
+### Added — `acr-image-updater-credentials` emits git write-back PAT Secret
+
+Image Updater v0.x cannot push git write-back commits via AAD
+authentication — only via HTTPS Basic (username:password). Add a
+third ExternalSecret to the component that reads a PAT from Key
+Vault (`image-updater-git-pat`) and produces an Opaque Secret
+readable by Image Updater via `git:secret:argocd/<name>`.
+
+- `templates/git-creds-external-secret.yaml` — new, gated by
+  `gitCreds.enabled` (defaults to `true` — Image Updater always needs
+  write-back for this component to be useful).
+- `values.yaml` — new `gitCreds.*` section.
+- Component chart `0.3.0` → `0.4.0` (MINOR — new feature, default-on).
+
+Paired Terraform: `transfero-acr-shared-hml` gained `image_updater_git_pat`
+variable (sensitive) + `azurerm_key_vault_secret.image_updater_git_pat`
+resource.
+
+Consumer Application annotation (set by app author, not this chart):
+
+```yaml
+argocd-image-updater.argoproj.io/write-back-method: git:secret:argocd/image-updater-git-creds
+argocd-image-updater.argoproj.io/git-repository: https://dev.azure.com/.../transfero-gitops
+```
+
+WIF migration (replaces PAT) tracked by
+[estabilis-platform-tools#160](https://github.com/Estabilis/estabilis-platform-tools/issues/160).
+
 ## [0.28.0] — 2026-04-21
 
 ### Changed — `acr-image-updater-credentials` credential mode defaults to SP

--- a/components/acr-image-updater-credentials/Chart.yaml
+++ b/components/acr-image-updater-credentials/Chart.yaml
@@ -1,17 +1,21 @@
 apiVersion: v2
 name: acr-image-updater-credentials
 description: |
-  ExternalSecrets that read ACR credentials from Key Vault and render
-  two Kubernetes Secrets:
-    1. A docker-config JSON Secret for ArgoCD Image Updater.
-    2. An ArgoCD repo-creds Secret so the repo-server can pull OCI
-       Helm charts from the same registry.
+  ExternalSecrets that read ACR + git credentials from Key Vault and
+  render up to three Kubernetes Secrets:
+    1. Docker-config for ArgoCD Image Updater registry auth.
+    2. ArgoCD repo-creds for repo-server OCI Helm pulls.
+    3. (Opt-in) Git PAT credentials for Image Updater write-back push.
 
-  Supports two credential modes:
+  ACR credential source switches on `credentialMode`:
     - sp (default) — Azure AD Service Principal with AcrPull RBAC.
       Preferred: tag listing works (AAD auth skips scope-map scope
       negotiation).
     - token — legacy repository-scoped token. Kept for rollback.
+
+  Git write-back credentials (opt-in via `gitCreds.enabled`) are an
+  independent HTTPS Basic credential Secret. WIF migration tracked
+  by estabilis-platform-tools#160.
 type: application
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.4.0
+appVersion: "0.4.0"

--- a/components/acr-image-updater-credentials/templates/git-creds-external-secret.yaml
+++ b/components/acr-image-updater-credentials/templates/git-creds-external-secret.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.gitCreds.enabled }}
+# --------------------------------------------------------------------
+# Image Updater — Git write-back credentials (separate from ACR creds).
+#
+# Image Updater v0.x cannot push to git via AAD; it needs static HTTPS
+# Basic credentials. This Secret is referenced by the consumer
+# Application via:
+#   argocd-image-updater.argoproj.io/write-back-method: git:secret:argocd/<secretName>
+# The Secret has two keys — `username` and `password` — both read
+# verbatim (no base64-of-user:pass like the ACR dockerconfig).
+#
+# WIF migration follow-up: estabilis-platform-tools#160.
+# --------------------------------------------------------------------
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.gitCreds.secretName }}
+  labels:
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: estabilis-platform
+    estabilis.io/component: acr-image-updater-credentials
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: platform-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: {{ .Values.gitCreds.secretName }}
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      type: Opaque
+      data:
+        username: {{ .Values.gitCreds.username | quote }}
+        password: '{{ "{{ .pat }}" }}'
+  data:
+    - secretKey: pat
+      remoteRef:
+        key: {{ .Values.gitCreds.kvSecretName }}
+{{- end }}

--- a/components/acr-image-updater-credentials/values.yaml
+++ b/components/acr-image-updater-credentials/values.yaml
@@ -42,3 +42,23 @@ token:
 # `acrLoginServer` is set; harmless if no Application pulls charts.
 repoCreds:
   secretName: cred-acr-shared-charts
+
+# Image Updater — Git write-back credentials (HTTPS Basic). Separate
+# KV secret because git push is unrelated to ACR pull. Consumer
+# Application references the rendered Secret via:
+#   argocd-image-updater.argoproj.io/write-back-method: git:secret:argocd/<secretName>
+#
+# Enabled by default — a deployment that runs Image Updater typically
+# also needs write-back to the gitops repo. Opt out (`enabled: false`)
+# for deployments that only read from the ACR and don't push back,
+# OR if the KV secret `image-updater-git-pat` is not populated. WIF
+# migration follow-up: estabilis-platform-tools#160.
+gitCreds:
+  enabled: true
+  secretName: image-updater-git-creds
+  # KV secret name created by `transfero-acr-shared-hml` Terraform
+  # (image_updater_git_pat variable).
+  kvSecretName: image-updater-git-pat
+  # PAT doesn't care about username — ADO accepts any non-empty value.
+  # Convention: use the PAT owner or a recognizable identity.
+  username: image-updater

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.28.0
-appVersion: "0.28.0"
+version: 0.29.0
+appVersion: "0.29.0"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.28.0
+repoVersion: v0.29.0
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
Completes the Image Updater write-back chain. Paired with `transfero-acr-shared-hml` terraform change that provisions KV secret `image-updater-git-pat` (ADO PAT, Code R+W scope).

## What's added

- `templates/git-creds-external-secret.yaml` — new ExternalSecret that reads the PAT from KV and renders an Opaque Secret with `username`/`password` for Image Updater's git:secret:<ns>/<name> reference.
- `values.yaml` — new `gitCreds.*` block, defaults enabled.
- Component chart 0.3.0 → 0.4.0 (MINOR).
- workload-bootstrap 0.28.0 → 0.29.0, values.yaml repoVersion v0.29.0.

## Why not AAD / WIF

Image Updater v0.x doesn't support AAD for git push. The WIF path (AAD → ADO token bridge) needs custom engineering — tracked by [estabilis-platform-tools#160](https://github.com/Estabilis/estabilis-platform-tools/issues/160). PAT is the pragmatic unblock.

## Downstream

After merge:
1. Tag v0.29.0 here
2. Bump client `platformGitopsVersion: v0.28.0 → v0.29.0` (v1.0.82)
3. PR in `transfero-gitops` adds to partner-service-hml Application:
   - `write-back-method: git:secret:argocd/image-updater-git-creds`
   - Self-ref bump
4. Client bump `clientGitopsRepoVersion` + terraform apply + promote
5. Image Updater finally closes the loop: SP auth ✅ → tag list ✅ → clone ✅ → commit ✅ → **push ✅** → write-back PR with real image tag+digest → ArgoCD syncs → pod Running