### PR TITLE
feat: multi-store ClusterSecretStore + secretStoreName param (v0.30.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,71 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.30.0] — 2026-04-22
+
+### Added — multi-store `ClusterSecretStore` + parametrized `secretStoreName`
+
+Two small but related additions that enable a cluster to read secrets
+from more than one Azure Key Vault, eliminating the need for a
+single-KV coupling between unrelated Terraform modules.
+
+**`components/cluster-secret-store`** — new `stores` list value.
+
+When `stores` is non-empty, the component renders one
+`ClusterSecretStore` per entry instead of the single hardcoded
+`platform-secret-store`. Each entry has its own `name` +
+`vaultUrl` + (optional) `tenantId`. When `stores` is empty
+(default), the legacy single-store behavior is preserved exactly
+— `vaultUrl` + `tenantId` at the top level produce the
+`platform-secret-store` used by every existing consumer.
+
+**`components/acr-image-updater-credentials`** — new
+`secretStoreName` value.
+
+Replaces the hardcoded `name: platform-secret-store` in three
+template locations (`external-secret.yaml` ×2,
+`git-creds-external-secret.yaml` ×1) with
+`{{ .Values.secretStoreName | default "platform-secret-store" }}`.
+Default preserves prior behavior; override when the 4 consumed KV
+secrets (`acr-shared-sp-client-id`, `acr-shared-sp-client-secret`,
+`acr-shared-token`, `image-updater-git-pat`) live in a separate
+Key Vault (e.g. a shared-infra KV owned by its own Terraform
+module).
+
+### Why
+
+Before this release, any code that stored secrets the cluster had
+to read was forced to write to the platform-owned KV — the only
+vault bound to the `external-secrets` managed identity in a single
+`ClusterSecretStore`. This created cross-module ownership coupling
+(observed in `transfero-acr-shared-hml`, which wrote 4 secrets
+into the platform KV `kv-transfero-hml-lmj060` simply because the
+cluster had no other way to read them).
+
+With multi-store + `secretStoreName`, a downstream module can own
+its own KV, provision a second `ClusterSecretStore` pointing at
+that KV, and have `acr-image-updater-credentials` read through it
+— without any platform code change. Companion PR in
+`estabilis-platform` v0.12.3 exposes the MI principal ID so the
+downstream module can grant `Key Vault Secrets User` on its own
+vault without duplicating the MI.
+
+### Compatibility
+
+- 100% backward compatible. Every existing consumer continues to
+  render identical YAML: `stores: []` falls back to single-store,
+  omitted `secretStoreName` defaults to `platform-secret-store`.
+- No template API breaks; no value renamed or removed.
+
+### Upgrade notes
+
+None required. The new capabilities activate only when the
+operator explicitly sets `stores` and/or `secretStoreName`.
+
+Companion repo bump: `estabilis-platform` v0.12.3 adds the
+`external_secrets_principal_id` output that shared-infra modules
+consume when wiring role assignments on their own KVs.
+
 ## [0.29.0] — 2026-04-22
 
 ### Added — `acr-image-updater-credentials` emits git write-back PAT Secret

--- a/components/acr-image-updater-credentials/templates/external-secret.yaml
+++ b/components/acr-image-updater-credentials/templates/external-secret.yaml
@@ -37,7 +37,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: platform-secret-store
+    name: {{ .Values.secretStoreName | default "platform-secret-store" }}
     kind: ClusterSecretStore
   target:
     name: acr-image-updater-credentials
@@ -82,7 +82,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: platform-secret-store
+    name: {{ .Values.secretStoreName | default "platform-secret-store" }}
     kind: ClusterSecretStore
   target:
     name: {{ .Values.repoCreds.secretName }}

--- a/components/acr-image-updater-credentials/templates/git-creds-external-secret.yaml
+++ b/components/acr-image-updater-credentials/templates/git-creds-external-secret.yaml
@@ -22,7 +22,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: platform-secret-store
+    name: {{ .Values.secretStoreName | default "platform-secret-store" }}
     kind: ClusterSecretStore
   target:
     name: {{ .Values.gitCreds.secretName }}

--- a/components/acr-image-updater-credentials/values.yaml
+++ b/components/acr-image-updater-credentials/values.yaml
@@ -2,6 +2,20 @@
 # global.sharedAcrLoginServer (Terraform → ConfigMap → helm parameter).
 acrLoginServer: ""
 
+# Name of the ClusterSecretStore this component's ExternalSecrets read
+# from. Default `platform-secret-store` matches the single-store form
+# provisioned by `components/cluster-secret-store` (legacy mode), so
+# existing deployments continue to work unchanged.
+#
+# Override when the 4 KV secrets this component consumes
+# (`acr-shared-sp-client-id`, `acr-shared-sp-client-secret`,
+# `acr-shared-token`, and `image-updater-git-pat`) live in a Key Vault
+# distinct from the platform KV. The target store must exist in the
+# cluster (provision via `components/cluster-secret-store` multi-store
+# mode) and the external-secrets MI must have `Key Vault Secrets User`
+# on the backing Key Vault.
+secretStoreName: platform-secret-store
+
 # -----------------------------------------------------------------------------
 # Credential source — two modes
 # -----------------------------------------------------------------------------

--- a/components/cluster-secret-store/templates/cluster-secret-store-azure.yaml
+++ b/components/cluster-secret-store/templates/cluster-secret-store-azure.yaml
@@ -1,3 +1,24 @@
+{{- /*
+  ClusterSecretStore renderer — two modes:
+
+  1. Single-store (legacy, default): when `.Values.stores` is empty,
+     renders one ClusterSecretStore named `platform-secret-store` with
+     vaultUrl/tenantId from top-level values. Preserves exact behavior
+     of versions before multi-store support.
+
+  2. Multi-store: when `.Values.stores` is a non-empty list, renders
+     one ClusterSecretStore per entry. Each entry: name, vaultUrl,
+     (optional) tenantId — falls back to top-level tenantId when the
+     per-entry value is omitted.
+
+  Use multi-store when the cluster needs to read secrets from more
+  than one Key Vault (e.g. platform KV + shared-infra KV owned by a
+  different Terraform module). The external-secrets MI must have
+  `Key Vault Secrets User` on every vault referenced here.
+*/ -}}
+{{- $stores := .Values.stores | default list -}}
+{{- if eq (len $stores) 0 -}}
+{{- /* Legacy single-store fallback (backward-compatible). */ -}}
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
@@ -8,3 +29,20 @@ spec:
       authType: WorkloadIdentity
       vaultUrl: {{ .Values.vaultUrl | quote }}
       tenantId: {{ .Values.tenantId | quote }}
+{{- else -}}
+{{- range $i, $s := $stores }}
+{{- if gt $i 0 }}
+---
+{{- end }}
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: {{ required "stores[].name is required" $s.name | quote }}
+spec:
+  provider:
+    azurekv:
+      authType: WorkloadIdentity
+      vaultUrl: {{ required "stores[].vaultUrl is required" $s.vaultUrl | quote }}
+      tenantId: {{ ($s.tenantId | default $.Values.tenantId) | quote }}
+{{- end }}
+{{- end }}

--- a/components/cluster-secret-store/values.yaml
+++ b/components/cluster-secret-store/values.yaml
@@ -1,3 +1,34 @@
-# Values injected via ArgoCD helm.parameters from platform-root
+# cluster-secret-store — ExternalSecrets ClusterSecretStore for Azure Key Vault.
+#
+# Two modes:
+#
+# 1) Single-store (default): top-level `vaultUrl` + `tenantId` produce
+#    one ClusterSecretStore named `platform-secret-store`. Backward-
+#    compatible with every version before multi-store support.
+#
+# 2) Multi-store: set `stores` to a non-empty list and each entry
+#    produces one ClusterSecretStore. Use this when the cluster needs
+#    to read secrets from more than one Key Vault (e.g. platform KV +
+#    shared-infra KV owned by a different module). The external-
+#    secrets MI must have `Key Vault Secrets User` on every vault
+#    listed here.
+#
+# When `stores` is non-empty, the top-level `vaultUrl` is ignored
+# (only `tenantId` stays as a fallback for entries that omit it).
+
 vaultUrl: ""
 tenantId: ""
+
+# Multi-store list. Each entry:
+#   - name: ClusterSecretStore resource name (must be unique cluster-wide)
+#   - vaultUrl: https://<kvname>.vault.azure.net/
+#   - tenantId: (optional) falls back to top-level `tenantId`
+#
+# Example:
+#
+# stores:
+#   - name: platform-secret-store
+#     vaultUrl: https://kv-transfero-hml-lmj060.vault.azure.net/
+#   - name: shared-infra-secret-store
+#     vaultUrl: https://kv-transfero-shared-infra-hml-xxxxx.vault.azure.net/
+stores: []

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.29.0
-appVersion: "0.29.0"
+version: 0.30.0
+appVersion: "0.30.0"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.29.0
+repoVersion: v0.30.0
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
## Summary

Two related, small additions that let a cluster read secrets from more than one Azure Key Vault, eliminating the single-KV coupling that today forces downstream modules to write their secrets into the platform KV.

## Changes

### `components/cluster-secret-store` — multi-instance mode

- New `stores` list value (default `[]`).
- When `stores` is non-empty, renders one `ClusterSecretStore` per entry (`name`, `vaultUrl`, optional `tenantId`).
- When `stores` is empty, renders the legacy single `ClusterSecretStore` named `platform-secret-store` from top-level `vaultUrl` + `tenantId` — **zero behavioral change** for existing consumers.
- `tenantId` is a required field for legacy mode and an optional per-entry value in multi-store mode (falls back to top-level).

### `components/acr-image-updater-credentials` — parametrized `secretStoreName`

- New top-level value `secretStoreName` (default `platform-secret-store`).
- Replaces 3 hardcoded references (`external-secret.yaml` ×2, `git-creds-external-secret.yaml` ×1).
- Default preserves prior behavior exactly.

## Why

The four KV secrets this component consumes (`acr-shared-sp-client-id`, `acr-shared-sp-client-secret`, `acr-shared-token`, `image-updater-git-pat`) are logically owned by a separate Terraform module (e.g. a client's shared-infra wrapper), **not** the platform. Today they have to be written into the platform-owned KV because that's the only vault the cluster's `external-secrets` MI can read (single-instance `ClusterSecretStore`, hardcoded name).

This release unblocks:

1. Shared-infra module provisions its **own** KV in its own RG.
2. Shared-infra grants `Key Vault Secrets User` on that KV to the platform's `external-secrets` MI via `external_secrets_principal_id` output (companion PR: `estabilis-platform` v0.12.3 — merged, tag `v0.12.3` pushed).
3. Cluster consumer sets `stores: [...]` (multi-store) to register a second `ClusterSecretStore` pointing at the new KV.
4. Cluster consumer sets `acr-image-updater-credentials.secretStoreName` to the new store name.

Result: end-to-end KV separation without any platform or gitops code duplication.

## Compatibility

- **100% backward compatible.** All defaults produce identical YAML to `v0.29.0`.
- Verified via `helm template` on both components in single-store and multi-store modes (see PR description discussion / internal validation).
- No value renamed or removed.

## Version bump

Lockstep across 3 files per `CLAUDE.md` §Cross-repo versioning rules:

- `workload-bootstrap/Chart.yaml` → `version: 0.30.0`, `appVersion: 0.30.0`
- `workload-bootstrap/values.yaml` → `repoVersion: v0.30.0`
- git tag `v0.30.0` (will be created on merge)

Minor bump (new capability, no break).

## Test plan

- [x] `helm template components/cluster-secret-store` default → 1 `ClusterSecretStore/platform-secret-store`, identical to v0.29.0.
- [x] `helm template components/cluster-secret-store` with `stores: [...]` → N `ClusterSecretStore` each with own name + vaultUrl.
- [x] `helm template components/acr-image-updater-credentials` default → all 3 `secretStoreRef.name: platform-secret-store`.
- [x] `helm template components/acr-image-updater-credentials` with `secretStoreName: foo` → all 3 `secretStoreRef.name: foo`.
- [ ] After merge + tag `v0.30.0`, downstream Transfero client bumps `platformGitopsVersion` and exercises multi-store end-to-end.

## Companion work

- `estabilis-platform` v0.12.3 (merged, tagged) — `external_secrets_principal_id` output.
- Next: `transfero-infra-shared-hml` (new client repo) will provision a dedicated KV + cross-KV role assignment using the new output.