### PR TITLE
feat(values): acr-image-updater-credentials platform overlay (v0.30.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.30.1] — 2026-04-22
+
+### Added — `values/platform/acr-image-updater-credentials.yaml` overlay
+
+Empty platform-level overlay file for `acr-image-updater-credentials`.
+Referenced by the Application template in estabilis-platform v0.12.4,
+which adds `valueFiles` to this Application so per-cluster overrides
+(e.g. `secretStoreName: shared-infra-secret-store`) can be declared
+without upstream changes.
+
+Patch bump: adds a new overlay file; no API change to the component
+chart itself. Lockstep across workload-bootstrap Chart.yaml + values.yaml.
+
 ## [0.30.0] — 2026-04-22
 
 ### Added — multi-store `ClusterSecretStore` + parametrized `secretStoreName`

--- a/values/platform/acr-image-updater-credentials.yaml
+++ b/values/platform/acr-image-updater-credentials.yaml
@@ -1,0 +1,5 @@
+# Platform overlay for acr-image-updater-credentials (empty)
+#
+# Gives downstream overrides (via overrideValueFile / gitopsValueFile)
+# a stable file to layer on top of the component's own values.yaml.
+# Rendered in valueFiles order by the Application template.

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.30.0
-appVersion: "0.30.0"
+version: 0.30.1
+appVersion: "0.30.1"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.30.0
+repoVersion: v0.30.1
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
## Summary

Adds empty `values/platform/acr-image-updater-credentials.yaml` overlay file, mirroring the `cluster-secret-store.yaml` pattern. Referenced by the Application template added in `estabilis-platform` v0.12.4 (companion PR).

## Why

estabilis-platform v0.12.4 adds a `valueFiles:` block to the `acr-image-updater-credentials` Application so downstream can override component values (e.g. `secretStoreName` for multi-KV separation). One of those valueFiles is `$values/values/platform/acr-image-updater-credentials.yaml` — this PR creates the file so the path resolves cleanly.

Empty payload — just a comment header. Overrides happen via the config-repo or gitops-repo override files.

## Version bump

Lockstep across 3 files per `CLAUDE.md` §Cross-repo versioning rules:

- `workload-bootstrap/Chart.yaml` → `version: 0.30.1`, `appVersion: 0.30.1`
- `workload-bootstrap/values.yaml` → `repoVersion: v0.30.1`
- Git tag `v0.30.1`

Patch — new file, no API change.

## Test plan

- [x] File renders as empty YAML (just comment) — confirmed.
- [ ] After merge + tag, used by estabilis-platform v0.12.4 valueFile path resolution.