### PR TITLE
feat: clientGitopsRepoRevision / configRepoRevision (v0.31.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,59 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.31.0] — 2026-04-22
+
+### Added — `clientGitopsRepoRevision` and `configRepoRevision` values
+
+Part of ADR 0020 (GitOps-native continuous reconciliation). Lets
+consumers track a branch (e.g. `main`, `release/prod`) instead of
+pinning a specific tag for **own-content repos** (client gitops +
+config overrides). Tag pinning for **external dependencies**
+(upstream Estabilis versions, container images, external helm
+charts) is unchanged.
+
+Changes:
+
+- `workload-bootstrap/values.yaml`: add `clientGitopsRepoRevision`
+  and `configRepoRevision`. Legacy `clientGitopsRepoVersion` and
+  `configRepoVersion` are **retained for backcompat** — when both
+  are set, the `*Revision` wins. When both are empty but the
+  corresponding URL is set, the helpers fail loudly.
+- `workload-bootstrap/templates/_helpers.tpl`: new helpers
+  `clientGitopsRefRequired`, `configRepoRefRequired`, and private
+  resolvers `clientGitopsRef` / `configRepoRef`. `overrideEnabled`
+  / `overrideSource` / `overrideValueFile` /
+  `ignoreMissingValueFiles` updated to consume `configRepoRef`
+  instead of `configRepoVersion` directly. `gitopsSource` consumes
+  `clientGitopsRefRequired`.
+- `workload-bootstrap/templates/client-apps.yaml`: ApplicationSet
+  generator `revision` and generated Application `targetRevision`
+  both use `clientGitopsRefRequired`.
+- `workload-bootstrap/templates/client-kyverno-exceptions.yaml`:
+  ApplicationSet source `targetRevision` uses
+  `clientGitopsRefRequired`.
+
+### Migration path
+
+- **No action required**: continue setting the legacy `*Version`
+  values. Chart renders identically to v0.30.1.
+- **Adopt branch tracking**: set `clientGitopsRepoRevision: main`
+  (or `release/prod` etc.), leave `clientGitopsRepoVersion` empty.
+  Same for `configRepoRevision`. Enables continuous reconciliation
+  per ADR 0020.
+
+### Compatibility
+
+100% backward-compatible. Verified via `helm template` in four
+modes: legacy-only, revision-only, both-set (revision wins), empty
+(fail loud with descriptive message).
+
+### Companion bump
+
+`estabilis-platform` v0.13.0 introduces the matching values at the
+platform-root chart level. Use both together when adopting
+continuous reconciliation.
+
 ## [0.30.1] — 2026-04-22
 
 ### Added — `values/platform/acr-image-updater-credentials.yaml` overlay

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.30.1
-appVersion: "0.30.1"
+version: 0.31.0
+appVersion: "0.31.0"

--- a/workload-bootstrap/templates/_helpers.tpl
+++ b/workload-bootstrap/templates/_helpers.tpl
@@ -136,26 +136,76 @@ Without both values set, all three helpers render nothing (no-op) and
 the ApplicationSets work exactly as before.
 */}}
 
+{{/*
+Ref resolver helpers — resolve the effective git ref (branch or tag)
+for each repo, preferring the new *Revision values over the legacy
+*Version values. Adopted in v0.31.0 per ADR 0020 (GitOps-native
+continuous reconciliation) to allow consumers to track branches
+(main / release/<env>) instead of pinning tags for own-content repos.
+
+Both the legacy (configRepoVersion / clientGitopsRepoVersion) and the
+new (configRepoRevision / clientGitopsRepoRevision) values are
+accepted. When both are set, the *Revision wins. When neither is set
+but the corresponding URL is configured, the helper fails loudly.
+
+Migration path for existing consumers:
+  - No action required: continue setting the legacy *Version value.
+  - To adopt branch tracking: unset *Version, set *Revision to a branch
+    name (e.g. "main") or tag.
+*/}}
+
+{{- define "workload-bootstrap.configRepoRef" -}}
+{{- if .Values.configRepoRevision -}}
+{{- .Values.configRepoRevision -}}
+{{- else if .Values.configRepoVersion -}}
+{{- .Values.configRepoVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "workload-bootstrap.configRepoRefRequired" -}}
+{{- $ref := include "workload-bootstrap.configRepoRef" . -}}
+{{- if not $ref -}}
+{{- fail "configRepoRevision (or legacy configRepoVersion) is required when configRepoUrl is set" -}}
+{{- end -}}
+{{- $ref -}}
+{{- end -}}
+
+{{- define "workload-bootstrap.clientGitopsRef" -}}
+{{- if .Values.clientGitopsRepoRevision -}}
+{{- .Values.clientGitopsRepoRevision -}}
+{{- else if .Values.clientGitopsRepoVersion -}}
+{{- .Values.clientGitopsRepoVersion -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "workload-bootstrap.clientGitopsRefRequired" -}}
+{{- $ref := include "workload-bootstrap.clientGitopsRef" . -}}
+{{- if not $ref -}}
+{{- fail "clientGitopsRepoRevision (or legacy clientGitopsRepoVersion) is required when clientGitopsRepoUrl is set" -}}
+{{- end -}}
+{{- $ref -}}
+{{- end -}}
+
 {{- define "workload-bootstrap.overrideEnabled" -}}
-{{- and .Values.configRepoUrl .Values.configRepoVersion -}}
+{{- and .Values.configRepoUrl (include "workload-bootstrap.configRepoRef" .) -}}
 {{- end -}}
 
 {{- define "workload-bootstrap.overrideSource" -}}
-{{- if and .Values.configRepoUrl .Values.configRepoVersion }}
+{{- if include "workload-bootstrap.overrideEnabled" . }}
 - repoURL: {{ .Values.configRepoUrl }}
-  targetRevision: {{ .Values.configRepoVersion }}
+  targetRevision: {{ include "workload-bootstrap.configRepoRefRequired" . }}
   ref: overrides
 {{- end }}
 {{- end -}}
 
 {{- define "workload-bootstrap.overrideValueFile" -}}
-{{- if and .root.Values.configRepoUrl .root.Values.configRepoVersion }}
+{{- if include "workload-bootstrap.overrideEnabled" .root }}
 - $overrides/overrides/{{ .component }}/values.yaml
 {{- end }}
 {{- end -}}
 
 {{- define "workload-bootstrap.ignoreMissingValueFiles" -}}
-{{- if and .Values.configRepoUrl .Values.configRepoVersion }}
+{{- if include "workload-bootstrap.overrideEnabled" . }}
 ignoreMissingValueFiles: true
 {{- end }}
 {{- end -}}
@@ -167,7 +217,7 @@ Client GitOps override helpers (ADR 0008 Tier 3).
 {{- define "workload-bootstrap.gitopsSource" -}}
 {{- if and .Values.clientGitopsRepoUrl .Values.deploymentId }}
 - repoURL: {{ .Values.clientGitopsRepoUrl }}
-  targetRevision: {{ required "clientGitopsRepoVersion is required when clientGitopsRepoUrl is set" .Values.clientGitopsRepoVersion }}
+  targetRevision: {{ include "workload-bootstrap.clientGitopsRefRequired" . }}
   ref: gitops
 {{- end }}
 {{- end -}}

--- a/workload-bootstrap/templates/client-apps.yaml
+++ b/workload-bootstrap/templates/client-apps.yaml
@@ -37,7 +37,7 @@ spec:
                   {{- toYaml .Values.clusterSelector.matchLabels | nindent 18 }}
           - git:
               repoURL: {{ .Values.clientGitopsRepoUrl | quote }}
-              revision: {{ required "clientGitopsRepoVersion is required when clientGitopsRepoUrl is set" .Values.clientGitopsRepoVersion | quote }}
+              revision: {{ include "workload-bootstrap.clientGitopsRefRequired" . | quote }}
               directories:
                 - path: "platforms/{{ .Values.deploymentId }}/apps/*"
   template:
@@ -56,7 +56,7 @@ spec:
         #    which ArgoCD applies as raw manifest (the Application itself
         #    references its own Helm chart source).
         - repoURL: {{ .Values.clientGitopsRepoUrl | quote }}
-          targetRevision: {{ required "clientGitopsRepoVersion is required when clientGitopsRepoUrl is set" .Values.clientGitopsRepoVersion | quote }}
+          targetRevision: {{ include "workload-bootstrap.clientGitopsRefRequired" . | quote }}
           path: "{{`{{ .path.path }}`}}"
           directory:
             recurse: false

--- a/workload-bootstrap/templates/client-kyverno-exceptions.yaml
+++ b/workload-bootstrap/templates/client-kyverno-exceptions.yaml
@@ -41,7 +41,7 @@ spec:
       project: workload-baseline
       source:
         repoURL: {{ .Values.clientGitopsRepoUrl | quote }}
-        targetRevision: {{ required "clientGitopsRepoVersion is required when clientGitopsRepoUrl is set" .Values.clientGitopsRepoVersion | quote }}
+        targetRevision: {{ include "workload-bootstrap.clientGitopsRefRequired" . | quote }}
         path: "platforms/{{ .Values.deploymentId }}/policies/exceptions"
         directory:
           recurse: true

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.30.1
+repoVersion: v0.31.0
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application
@@ -110,7 +110,15 @@ components:
 # workload-bootstrap — the hub passes the client's downstream repo
 # URL and version as helm parameters.
 configRepoUrl: ""
-configRepoVersion: ""
+
+# Git ref for the config repo. Prefer `configRepoRevision` (added
+# v0.31.0 per ADR 0020) which accepts branches (main / release/<env>)
+# for continuous reconciliation OR tags for pinned releases.
+# `configRepoVersion` is retained for backcompat — when both are
+# set, `configRepoRevision` wins. When both are empty but
+# `configRepoUrl` is set, the helpers fail loudly.
+configRepoRevision: ""
+configRepoVersion: ""  # DEPRECATED: use configRepoRevision
 
 # ---------------------------------------------------------------------------
 # Client GitOps repo (ADR 0008 Tier 3 — per-client override source)
@@ -120,7 +128,15 @@ configRepoVersion: ""
 # (and future components) can read per-platform overrides from the
 # client's gitops repo.
 clientGitopsRepoUrl: ""
-clientGitopsRepoVersion: ""
+
+# Git ref for the client gitops repo. Prefer `clientGitopsRepoRevision`
+# (added v0.31.0 per ADR 0020) which accepts branches (main /
+# release/<env>) for continuous reconciliation OR tags for pinned
+# releases. `clientGitopsRepoVersion` is retained for backcompat —
+# when both are set, `clientGitopsRepoRevision` wins.
+clientGitopsRepoRevision: ""
+clientGitopsRepoVersion: ""  # DEPRECATED: use clientGitopsRepoRevision
+
 deploymentId: ""
 
 # Scheduling policy per component (ADR 0012 — tracked in


### PR DESCRIPTION
## Summary

Phase 1 of ADR 0020 (GitOps-native continuous reconciliation). Adds new `*Revision` values to `workload-bootstrap` that accept branch names (`main`, `release/prod`) in addition to tags, letting consumer clusters track continuous reconciliation for own-content repos instead of forcing the bump cascade that the pin pattern requires.

Image tag + digest pinning (supply chain) and upstream Estabilis version pinning (API versioning) are **unchanged**.

## Changes

- `workload-bootstrap/values.yaml`: add `clientGitopsRepoRevision` + `configRepoRevision`. Legacy `*Version` retained.
- `workload-bootstrap/templates/_helpers.tpl`: new helpers `clientGitopsRefRequired` / `configRepoRefRequired` resolve Revision-first, fallback to Version, fail loudly when URL is set but ref missing.
- `client-apps.yaml`: ApplicationSet generator + generated Application consume the new helper.
- `client-kyverno-exceptions.yaml`: same substitution.

## Compatibility

**100% backward-compatible.** Verified via `helm template` in 4 modes:

- Legacy-only (`clientGitopsRepoVersion=v1.11.34`) → renders identical to v0.30.1
- Revision-only (`clientGitopsRepoRevision=main`) → renders `main`
- Both set → Revision wins
- Neither set (with URL) → fail loud with descriptive message pointing to migration path

## Companion bump

`estabilis-platform` v0.13.0 adds matching values at the platform-root chart level. They ship together.

## Migration path for consumers

- No action required: continue setting the legacy `*Version` values.
- To adopt continuous reconciliation: set `*Revision: main` (or `release/prod`), leave `*Version` empty.

## Version bump

Lockstep per CLAUDE.md §Cross-repo versioning rules:
- `Chart.yaml` version + appVersion → `0.31.0`
- `values.yaml` repoVersion → `v0.31.0`
- Git tag `v0.31.0`

Minor bump — new capability, no break.

## Test plan

- [x] `helm template` legacy mode renders identical to v0.30.1
- [x] `helm template` revision mode renders branch name
- [x] `helm template` both-set → Revision wins
- [x] `helm template` empty-ref fails loud
- [ ] After merge + tag, Phase 2 (estabilis-platform v0.13.0) consumes this release
- [ ] After Phase 2 + Phase 3 Transfero HML adoption, cluster validates continuous reconciliation

## Relates to

ADR 0020 (PR #164 in estabilis-platform-tools) — reference design document.