### PR TITLE
fix: inject-pss-labels CRD defaults (v0.32.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,36 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.32.0] — 2026-04-22
+
+### Fixed — `inject-pss-labels` infinite drift (Kyverno CRD defaults)
+
+The `kyverno-policies/templates/inject-pss-labels.yaml` template
+omitted three fields that Kyverno's CRD defaults populate on admission:
+
+- `admission: true`
+- `emitWarning: false`
+- `validationFailureAction: Audit`
+
+When ArgoCD applied the git manifest without these fields, Kyverno
+admitted the resource and added them; ArgoCD then compared git
+(3 fields missing) vs live (3 fields present) → infinite
+`OutOfSync Healthy`. The policy functioned correctly throughout
+— only the reconciliation status was broken.
+
+Declaring the defaults explicitly in the template matches the
+admitted form, closing the drift. Behavior unchanged.
+
+Observed on Transfero HML 2026-04-22 after ADR 0020 migration
+triggered a mass re-render: `kyverno-policies-transfero-workload-hml-eastus2`
+reported OutOfSync with one failing resource (ClusterPolicy/inject-pss-labels).
+
+### Version
+
+`v0.31.0 → v0.32.0`. Minor bump — no behavior change, but consumer
+clusters render a slightly different (now fully-declared) manifest,
+which ArgoCD will apply on next reconcile.
+
 ## [0.31.0] — 2026-04-22
 
 ### Added — `clientGitopsRepoRevision` and `configRepoRevision` values

--- a/components/kyverno-policies/templates/inject-pss-labels.yaml
+++ b/components/kyverno-policies/templates/inject-pss-labels.yaml
@@ -15,6 +15,15 @@ metadata:
       and .extraPrivilegedNamespaces get enforce=privileged.
       All other platform namespaces get enforce=baseline with warn/audit=restricted.
 spec:
+  # Declare Kyverno CRD defaults explicitly. When omitted, Kyverno
+  # populates these on admission with defaults — ArgoCD then sees
+  # field-level diff between git (missing) and live (populated) →
+  # infinite OutOfSync. Declaring matches the admitted form and
+  # eliminates the drift. Functional behavior unchanged (these ARE
+  # the CRD defaults).
+  admission: true
+  emitWarning: false
+  validationFailureAction: Audit
   background: true
   rules:
     - name: inject-pss-restricted-client

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.31.0
-appVersion: "0.31.0"
+version: 0.32.0
+appVersion: "0.32.0"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.31.0
+repoVersion: v0.32.0
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
## Summary

Fix infinite drift on `inject-pss-labels` ClusterPolicy. Kyverno CRD defaults (`admission`, `emitWarning`, `validationFailureAction`) were omitted from the template; Kyverno populated them on admission; ArgoCD saw drift. Declaring defaults explicitly eliminates the mismatch.

Functional behavior unchanged (these are the CRD defaults per Kyverno spec).

## Observed

Transfero HML 2026-04-22 post-ADR-0020 migration — `kyverno-policies-transfero-workload-hml-eastus2` reported OutOfSync with one failing resource (ClusterPolicy/inject-pss-labels).

## Version

v0.31.0 → v0.32.0 (minor — template change, consumer clusters re-apply the declaration on next reconcile).