### PR TITLE
feat(ci): Phase 1 — add release + gitleaks workflows

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -1,0 +1,59 @@
+name: gitleaks
+
+# Hard-gate secret scanning using the gitleaks CLI binary directly
+# (Apache 2.0). This avoids the gitleaks-action v2 requirement for a
+# GITLEAKS_LICENSE secret, which is free for orgs but still needs one-time
+# registration + secret provisioning per org. The trade-off is less
+# convenience (no inline PR annotations), in exchange for zero
+# registration + zero telemetry.
+#
+# Binary version is pinned and kept in sync with the rev in
+# .pre-commit-config.yaml, so CI and local developer setups produce the
+# same findings.
+#
+# Shares .gitleaks.toml with the local pre-commit setup — single source of
+# truth for allowlists and custom rules.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: gitleaks-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      # Keep in sync with the `rev:` field in .pre-commit-config.yaml for
+      # the gitleaks hook. When bumping, update both places.
+      GITLEAKS_VERSION: "8.21.2"
+
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -fsSL "$url" | tar -xz
+          sudo mv gitleaks /usr/local/bin/
+          gitleaks version
+
+      - name: Scan full history
+        run: |
+          gitleaks detect \
+            --source=. \
+            --config=.gitleaks.toml \
+            --redact \
+            --verbose

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,123 @@
+name: release
+
+# Detects `chore(release): vX.Y.Z` commits on main and:
+#   1. Creates an annotated git tag `vX.Y.Z` pointing at the commit
+#   2. Creates a GitHub Release with the CHANGELOG section extracted
+#      between `## [X.Y.Z]` and the next `## [`
+#
+# Operator workflow:
+#   - Merge feature PRs normally (squash or merge, doesn't matter)
+#   - When ready to release, create a dedicated commit on main with the
+#     subject `chore(release): vX.Y.Z` (via a small PR or direct push —
+#     the workflow handles both).
+#   - This workflow tags + releases. No manual `git tag` / `git push --tags`
+#     required.
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write # needs to push the tag + create the release
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # need full history for CHANGELOG extraction
+
+      - name: Detect release commit
+        id: detect
+        run: |
+          set -euo pipefail
+          subject=$(git log -1 --pretty=%s)
+          echo "Last commit subject: $subject"
+          if [[ "$subject" =~ ^chore\(release\):\ v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            version="v${BASH_REMATCH[1]}"
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            echo "version=$version" >> "$GITHUB_OUTPUT"
+            echo "Detected release: $version"
+          else
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "Not a release commit — skipping."
+          fi
+
+      - name: Guard against duplicate tag
+        if: steps.detect.outputs.should_release == 'true'
+        run: |
+          set -euo pipefail
+          version="${{ steps.detect.outputs.version }}"
+          if git rev-parse "refs/tags/$version" >/dev/null 2>&1; then
+            echo "::error::Tag $version already exists. Either the release commit is being replayed, or a manual tag was created out of band."
+            exit 1
+          fi
+
+      - name: Extract CHANGELOG section
+        if: steps.detect.outputs.should_release == 'true'
+        id: changelog
+        run: |
+          set -euo pipefail
+          version_bare="${{ steps.detect.outputs.version }}"
+          version_bare="${version_bare#v}"
+
+          # AWK extracts lines between `## [X.Y.Z]` (exclusive of header)
+          # and the next `## [` marker. Stops on first match only.
+          body=$(awk -v ver="$version_bare" '
+            BEGIN { found=0; done=0 }
+            /^## \[/ {
+              if (found) { done=1 }
+              if ($0 ~ "^## \\[" ver "\\]") { found=1; next }
+            }
+            found && !done { print }
+          ' CHANGELOG.md)
+
+          if [[ -z "$body" ]]; then
+            echo "::warning::No CHANGELOG section found for $version_bare — using a generic message."
+            body="Release $version_bare. See CHANGELOG.md for the full list of changes."
+          fi
+
+          # Multi-line output via heredoc delimiter
+          {
+            echo 'body<<RELEASE_NOTES_EOF'
+            echo "$body"
+            echo 'RELEASE_NOTES_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create annotated tag
+        if: steps.detect.outputs.should_release == 'true'
+        env:
+          VERSION: ${{ steps.detect.outputs.version }}
+          BODY: ${{ steps.changelog.outputs.body }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Build the tag message in a file — using -m with embedded newlines
+          # is brittle inside YAML block scalars.
+          printf '%s\n\n%s\n' "$VERSION" "$BODY" > /tmp/tag-message.txt
+          git tag -a "$VERSION" -F /tmp/tag-message.txt
+          git push origin "$VERSION"
+          echo "Tag $VERSION pushed."
+
+      - name: Create GitHub Release
+        if: steps.detect.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.detect.outputs.version }}
+          BODY: ${{ steps.changelog.outputs.body }}
+        run: |
+          set -euo pipefail
+          gh release create "$VERSION" \
+            --title "$VERSION" \
+            --notes "$BODY" \
+            --target "$GITHUB_SHA"
+          echo "GitHub Release $VERSION created."

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,53 @@
+# Gitleaks configuration for estabilis-platform.
+#
+# Extends the default ruleset with an allowlist calibrated for the
+# documentation and example patterns used throughout this repo.
+
+title = "estabilis-platform gitleaks config"
+
+[extend]
+# Load the maintained default rules from upstream, then apply the overrides
+# below. Keeps coverage current without re-declaring every rule.
+useDefault = true
+
+# ---------------------------------------------------------------------------
+# Global allowlist — paths and patterns that may contain secret-like
+# strings that are NOT real secrets (documentation, placeholders, UUIDs in
+# variable descriptions, etc.).
+# ---------------------------------------------------------------------------
+
+[allowlist]
+description = "Documentation, changelog, ADRs, and placeholder values"
+
+paths = [
+  '''^\.pre-commit-config\.yaml$''',
+  '''^\.gitleaks\.toml$''',
+  '''^CHANGELOG\.md$''',
+  '''^README\.md$''',
+  '''^CLAUDE\.md$''',
+  '''^LICENSE$''',
+  '''^docs/adr/.*\.md$''',
+  '''^docs/.*\.md$''',
+  # Terraform lock files are provider signature hashes, not secrets.
+  '''\.terraform\.lock\.hcl$''',
+]
+
+regexes = [
+  # Example / placeholder tokens — frequent in docs and variable defaults.
+  '''EXAMPLE[-_]?(TOKEN|SECRET|KEY|PASSWORD)''',
+  '''<[A-Z_]+>''',                       # <TOKEN>, <SECRET>, etc.
+  '''(?i)your[-_]?(token|key|secret)''', # your-token, YOUR_KEY, etc.
+  '''xxxx+''',                           # xxxxxxxx placeholder
+  # UUID-looking strings used as Azure subscription/tenant/Cloudflare zone
+  # placeholders in variable descriptions. Real UUIDs never land in committed
+  # code — they live in .tfvars (gitignored) or Secrets Manager.
+  '''\b00000000-0000-0000-0000-000000000000\b''',
+]
+
+stopwords = [
+  "example",
+  "placeholder",
+  "dummy",
+  "fake",
+  "sample",
+]


### PR DESCRIPTION
Partial Phase 1 CI replication from Estabilis/estabilis-platform#73. The existing `lint.yml` already covers the repo-specific pre-commit hooks (ApplicationSet syntax, Helm trim-markers, inline ignoreMissingValueFiles, pinned git refs), so I'm not adding a generic `pre-commit.yaml`.

Adds:
- `.gitleaks.toml` — shared secret-scan config mirrored from upstream
- `.github/workflows/gitleaks.yaml` — full-history scan via gitleaks binary
- `.github/workflows/release.yaml` — auto-tag + GitHub Release on `chore(release): vX.Y.Z` merge

Tracked in Estabilis/estabilis-platform-tools#175.