### PR TITLE
chore(release): v0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,43 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.33.0] — 2026-04-24
+
+### Added — AWS provider overlays for platform hub components
+
+Introduces two new per-provider overlay files under `values/platform/`
+loaded by the hub's `platform-root` Application via the existing
+`$values/values/platform/<component>-{{ .Values.global.provider }}.yaml`
+convention. Both files wire the respective ServiceAccount for IRSA so
+the controller pods can authenticate against AWS APIs via the IAM
+roles already provisioned by `estabilis-platform/providers/aws/iam.tf`.
+
+- `values/platform/cert-manager-aws.yaml` — cert-manager controller SA
+  IRSA annotation. Paired with `module.cert_manager_irsa` (gated on
+  `dns_provider = "route53"`). Enables Route53 DNS-01 solving for the
+  `letsencrypt-production` ClusterIssuer on EKS hub clusters.
+
+- `values/platform/external-secrets-aws.yaml` — external-secrets
+  controller SA IRSA annotation. Paired with
+  `module.external_secrets_irsa`. Enables the ClusterSecretStore
+  (already AWS-aware in `cluster-secret-store.yaml`) to read from AWS
+  Secrets Manager.
+
+Both overlays expose `serviceAccount.annotations.eks.amazonaws.com/role-arn`
+as an injection point. The value is injected per-cluster by
+`platform-root` as a Helm parameter (wired in PR #2 of
+`Estabilis/estabilis-platform-tools#186`).
+
+Files are additive — Azure overlays (`cert-manager-azure.yaml`,
+`external-secrets-azure.yaml`) remain unchanged; the upstream
+`platform-root` template selects exactly one overlay per render based
+on `global.provider`.
+
+### Version
+
+`v0.32.0 → v0.33.0`. Minor bump — new provider support, no breaking
+changes. Existing Azure deployments continue rendering identically.
+
 ## [0.32.0] — 2026-04-22
 
 ### Fixed — `inject-pss-labels` infinite drift (Kyverno CRD defaults)

--- a/values/platform/cert-manager-aws.yaml
+++ b/values/platform/cert-manager-aws.yaml
@@ -1,0 +1,19 @@
+# AWS-specific overlay for cert-manager on the hub cluster
+# Loaded in addition to cert-manager.yaml when global.provider=aws.
+#
+# Wires the cert-manager controller pod for IRSA so the DNS-01 solver
+# (ClusterIssuer letsencrypt-production) can authenticate against
+# Route53 via the dedicated IAM role (module.cert_manager_irsa in
+# providers/aws/iam.tf, gated on dns_provider = "route53").
+#
+# Without this annotation the SA cannot assume the role and the
+# challenge fails with:
+#   "WebIdentityErr: failed to retrieve credentials"
+#
+# The roleArn is dynamic per-cluster and is injected as a helm
+# parameter by platform-root (see bootstrap/platform-root/templates/
+# cert-manager.yaml).
+
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: ""  # injected via helm.parameter

--- a/values/platform/external-secrets-aws.yaml
+++ b/values/platform/external-secrets-aws.yaml
@@ -1,0 +1,19 @@
+# AWS-specific overlay for External Secrets Operator (platform)
+# Loaded in addition to external-secrets.yaml when global.provider=aws.
+#
+# Wires the ESO controller pod for IRSA so the ClusterSecretStore (AWS
+# Secrets Manager, defined in bootstrap/platform-root/templates/
+# cluster-secret-store.yaml) can authenticate via the dedicated IAM
+# role (module.external_secrets_irsa in providers/aws/iam.tf).
+#
+# Without this annotation the SA cannot assume the role and the store
+# fails with:
+#   "WebIdentityErr: failed to retrieve credentials"
+#
+# The roleArn is dynamic per-cluster and is injected as a helm
+# parameter by platform-root (see bootstrap/platform-root/templates/
+# external-secrets.yaml).
+
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: ""  # injected via helm.parameter

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.32.0
-appVersion: "0.32.0"
+version: 0.33.0
+appVersion: "0.33.0"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.32.0
+repoVersion: v0.33.0
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
## Summary

Adds two AWS-specific overlay files under `values/platform/` to enable hub cluster components (cert-manager, external-secrets) to authenticate via IRSA on EKS. Azure deployments are unaffected — the platform-root template selects one overlay per render based on `global.provider`.

## Files

- `values/platform/cert-manager-aws.yaml` — cert-manager SA IRSA annotation. Paired with `module.cert_manager_irsa` in `estabilis-platform/providers/aws/iam.tf` (gated on `dns_provider = "route53"`). Enables Route53 DNS-01 solving for `letsencrypt-production`.
- `values/platform/external-secrets-aws.yaml` — external-secrets SA IRSA annotation. Paired with `module.external_secrets_irsa`. Enables the AWS-aware `ClusterSecretStore` (already wired in `cluster-secret-store.yaml`) to read from AWS Secrets Manager.
- `workload-bootstrap/Chart.yaml` — `version` + `appVersion` bumped to `0.33.0`
- `workload-bootstrap/values.yaml` — `repoVersion` bumped to `v0.33.0`
- `CHANGELOG.md` — entry for 0.33.0

## Value injection

Both overlays expose `serviceAccount.annotations.eks.amazonaws.com/role-arn` as an injection point with an empty default. The actual ARN is provided per-cluster by `platform-root` as a Helm parameter, wired in the companion PR on `estabilis-platform` (not yet opened — follow-up after this tag lands).

## Why no `platform-secrets-aws.yaml`

Investigated: the `platform-secrets` chart itself is provider-agnostic (it references `platform-secret-store` which is the `ClusterSecretStore` already AWS-aware in `cluster-secret-store.yaml`). The AWS gap for platform-secrets is in the `platform-root` template's outer condition (`{{- if eq .Values.global.provider "azure" }}`), not in the chart or its values. That fix lives in the companion PR.

## Test plan

- [x] 4 custom pre-commit hooks pass (goTemplate syntax, trim-markers, ignoreMissingValueFiles helper, pin git refs)
- [x] `helm lint workload-bootstrap` passes (no changes to rendering)
- [ ] CI: lint + gitleaks workflows green
- [ ] CI: release workflow detects `chore(release): v0.33.0` subject and publishes tag `v0.33.0` + GitHub Release

## Release path

PR title uses the `chore(release): vX.Y.Z` format so that on squash-merge the final commit on main matches the regex in `.github/workflows/release.yaml` and the tag is created automatically.

## Related

- Tracker: Estabilis/estabilis-platform-tools#186 — AWS provider branches in core templates
- Audit: Estabilis/estabilis-platform-tools#185 — provider-selective values overlays
- Next: companion PR on `estabilis-platform` adds the 5 AWS branches in `platform-root/templates/` and bumps `platformGitopsVersion` to `v0.33.0`