### PR TITLE
feat(cluster-secret-store): AWS provider via ExternalSecrets AWS Secrets Manager (v0.34.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,40 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.34.0] — 2026-04-24
+
+### Added — `components/cluster-secret-store` chart now supports AWS provider
+
+The chart had a single Azure template (`cluster-secret-store-azure.yaml`)
+that unconditionally rendered an `azurekv`-backed ClusterSecretStore.
+This release adds:
+
+- A new `provider` top-level value. Defaults to `"azure"` for
+  backcompat — existing Azure downstreams see zero change.
+- `cluster-secret-store-aws.yaml`: rendered when `provider: aws`,
+  produces an ExternalSecrets `ClusterSecretStore` using the AWS
+  Secrets Manager provider, authenticated via IRSA (JWT/
+  `serviceAccountRef`).
+- New values fields:
+  - `region` (required on AWS; falls back per-store when `stores` is set)
+  - `aws.serviceAccount.{name,namespace}` — defaults `external-secrets/external-secrets`
+
+### Migration
+
+- Azure downstreams: no action. `provider` defaults to `azure`.
+- AWS downstreams: set `provider: aws`, `region: <aws-region>` in
+  `overrides/platform-root/values.yaml` (or equivalent) and ensure the
+  `external-secrets` ServiceAccount carries the IRSA annotation
+  (already wired by `providers/aws/iam.tf` →
+  `module.external_secrets_irsa`).
+
+### Consumer alignment
+
+`estabilis-platform` v0.19.0+ passes `provider: {{ .Values.global.provider }}`
+as a helm parameter from `bootstrap/platform-root/templates/cluster-secret-store.yaml`.
+Older `estabilis-platform` versions send no `provider` parameter and the
+chart falls back to Azure — still safe for Azure-only deployments.
+
 ## [0.33.0] — 2026-04-24
 
 ### Added — AWS provider overlays for platform hub components

--- a/components/cluster-secret-store/templates/cluster-secret-store-aws.yaml
+++ b/components/cluster-secret-store/templates/cluster-secret-store-aws.yaml
@@ -1,0 +1,70 @@
+{{- /*
+  ClusterSecretStore renderer (AWS branch).
+
+  Uses External Secrets Operator's `aws` provider backed by AWS Secrets
+  Manager. Authentication goes through IRSA — the external-secrets
+  controller ServiceAccount is annotated with an IAM role ARN whose
+  trust policy allows the controller to assume it via the EKS OIDC
+  provider. ESO then uses the resulting STS token to call Secrets
+  Manager APIs.
+
+  Two modes (mirror the azure side):
+
+  1. Single-store (default): when `.Values.stores` is empty, renders
+     one ClusterSecretStore named `platform-secret-store` pointing at
+     the top-level `region`. The secrets-path prefix / naming
+     convention is enforced elsewhere (by ESO ExternalSecret resources
+     that reference this store).
+
+  2. Multi-store: `.Values.stores` list, one ClusterSecretStore per
+     entry. Each entry: name, (optional) region — falls back to
+     top-level `region`.
+
+  The external-secrets controller ServiceAccount name + namespace are
+  configurable via `.Values.aws.serviceAccount.{name,namespace}` and
+  default to `external-secrets` / `external-secrets`, matching the
+  chart's defaults used on EKS.
+*/ -}}
+{{- $provider := .Values.provider | default "azure" -}}
+{{- if eq $provider "aws" -}}
+{{- $saName := .Values.aws.serviceAccount.name | default "external-secrets" -}}
+{{- $saNamespace := .Values.aws.serviceAccount.namespace | default "external-secrets" -}}
+{{- $stores := .Values.stores | default list -}}
+{{- if eq (len $stores) 0 -}}
+{{- /* Legacy single-store fallback. */ -}}
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: platform-secret-store
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: {{ required "region is required on AWS" .Values.region | quote }}
+      auth:
+        jwt:
+          serviceAccountRef:
+            name: {{ $saName | quote }}
+            namespace: {{ $saNamespace | quote }}
+{{- else -}}
+{{- range $i, $s := $stores }}
+{{- if gt $i 0 }}
+---
+{{- end }}
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: {{ required "stores[].name is required" $s.name | quote }}
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: {{ ($s.region | default $.Values.region | required "stores[].region or top-level region is required on AWS") | quote }}
+      auth:
+        jwt:
+          serviceAccountRef:
+            name: {{ $saName | quote }}
+            namespace: {{ $saNamespace | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/components/cluster-secret-store/templates/cluster-secret-store-azure.yaml
+++ b/components/cluster-secret-store/templates/cluster-secret-store-azure.yaml
@@ -1,5 +1,5 @@
 {{- /*
-  ClusterSecretStore renderer — two modes:
+  ClusterSecretStore renderer (Azure branch) — two modes:
 
   1. Single-store (legacy, default): when `.Values.stores` is empty,
      renders one ClusterSecretStore named `platform-secret-store` with
@@ -15,7 +15,13 @@
   than one Key Vault (e.g. platform KV + shared-infra KV owned by a
   different Terraform module). The external-secrets MI must have
   `Key Vault Secrets User` on every vault referenced here.
+
+  AWS provider is handled by cluster-secret-store-aws.yaml. Gate on
+  `.Values.provider` — defaults to "azure" for backcompat so existing
+  Azure downstreams see no change.
 */ -}}
+{{- $provider := .Values.provider | default "azure" -}}
+{{- if eq $provider "azure" -}}
 {{- $stores := .Values.stores | default list -}}
 {{- if eq (len $stores) 0 -}}
 {{- /* Legacy single-store fallback (backward-compatible). */ -}}
@@ -44,5 +50,6 @@ spec:
       authType: WorkloadIdentity
       vaultUrl: {{ required "stores[].vaultUrl is required" $s.vaultUrl | quote }}
       tenantId: {{ ($s.tenantId | default $.Values.tenantId) | quote }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/components/cluster-secret-store/values.yaml
+++ b/components/cluster-secret-store/values.yaml
@@ -1,34 +1,66 @@
-# cluster-secret-store — ExternalSecrets ClusterSecretStore for Azure Key Vault.
+# cluster-secret-store — ExternalSecrets ClusterSecretStore.
 #
-# Two modes:
+# Provider selection (v0.34.0+):
+#   - provider: azure  (default, backward-compatible)  → uses Azure Key Vault
+#   - provider: aws                                    → uses AWS Secrets Manager
 #
-# 1) Single-store (default): top-level `vaultUrl` + `tenantId` produce
-#    one ClusterSecretStore named `platform-secret-store`. Backward-
-#    compatible with every version before multi-store support.
+# Azure + AWS share the same multi-store semantics; each provider reads
+# a provider-specific subset of fields. When `stores` is empty the
+# chart renders a single legacy `platform-secret-store` with top-level
+# fields.
+
+provider: azure
+
+# --------------------- Azure provider ---------------------------------
 #
-# 2) Multi-store: set `stores` to a non-empty list and each entry
-#    produces one ClusterSecretStore. Use this when the cluster needs
-#    to read secrets from more than one Key Vault (e.g. platform KV +
-#    shared-infra KV owned by a different module). The external-
-#    secrets MI must have `Key Vault Secrets User` on every vault
-#    listed here.
+# Required when provider=azure.
 #
-# When `stores` is non-empty, the top-level `vaultUrl` is ignored
-# (only `tenantId` stays as a fallback for entries that omit it).
+# Single-store: top-level `vaultUrl` + `tenantId`.
+# Multi-store: `stores` with per-entry `vaultUrl` + (optional) `tenantId`
+# (falls back to top-level tenantId).
 
 vaultUrl: ""
 tenantId: ""
 
-# Multi-store list. Each entry:
-#   - name: ClusterSecretStore resource name (must be unique cluster-wide)
-#   - vaultUrl: https://<kvname>.vault.azure.net/
-#   - tenantId: (optional) falls back to top-level `tenantId`
+# --------------------- AWS provider -----------------------------------
 #
-# Example:
+# Required when provider=aws.
+#
+# Single-store: top-level `region` used as the AWS region for Secrets
+# Manager.
+# Multi-store: `stores` entries may override `region` per-entry; fall
+# back to top-level `region`.
+#
+# `aws.serviceAccount.{name,namespace}` reference the external-secrets
+# controller ServiceAccount annotated with an IRSA role ARN (wired by
+# Terraform; see providers/aws/iam.tf → module.external_secrets_irsa).
+
+region: ""
+
+aws:
+  serviceAccount:
+    name: external-secrets
+    namespace: external-secrets
+
+# ---------------------- Multi-store list ------------------------------
+#
+# Each entry:
+#   - name: ClusterSecretStore resource name (must be unique cluster-wide)
+#   - vaultUrl: (azure only) https://<kvname>.vault.azure.net/
+#   - tenantId: (azure only, optional) falls back to top-level `tenantId`
+#   - region:   (aws only, optional) falls back to top-level `region`
+#
+# Example (Azure):
 #
 # stores:
 #   - name: platform-secret-store
 #     vaultUrl: https://kv-transfero-hml-lmj060.vault.azure.net/
 #   - name: shared-infra-secret-store
 #     vaultUrl: https://kv-transfero-shared-infra-hml-xxxxx.vault.azure.net/
+#
+# Example (AWS):
+#
+# stores:
+#   - name: platform-secret-store
+#     region: us-east-1
 stores: []

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.33.0
-appVersion: "0.33.0"
+version: 0.34.0
+appVersion: "0.34.0"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.33.0
+repoVersion: v0.34.0
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
## Summary

Adds AWS Secrets Manager support to the `components/cluster-secret-store` chart. Previously the chart had only an Azure Key Vault template that rendered unconditionally; new AWS deployments had no ClusterSecretStore resource, so ExternalSecrets could not reconcile platform-secrets on AWS.

## Changes

- New top-level value `provider` (default `azure` for backcompat).
- `cluster-secret-store-azure.yaml` gated on `provider == "azure"`.
- New `cluster-secret-store-aws.yaml` gated on `provider == "aws"` — renders an ExternalSecrets `ClusterSecretStore` using the AWS Secrets Manager provider, authenticated via IRSA (JWT `serviceAccountRef`).
- New values:
  - `region` — required on AWS (top-level or per-store)
  - `aws.serviceAccount.{name,namespace}` — defaults `external-secrets/external-secrets`
- `workload-bootstrap/Chart.yaml` version + appVersion: `0.33.0 → 0.34.0`
- `workload-bootstrap/values.yaml` `repoVersion: v0.34.0`
- `CHANGELOG.md` entry

## Consumer alignment

`estabilis-platform v0.19.0` (in-flight PR) passes `provider: {{ .Values.global.provider }}` as a helm parameter from `bootstrap/platform-root/templates/cluster-secret-store.yaml`. Older platform versions don't pass provider and the chart falls back to Azure — Azure-only deployments are entirely unaffected.

## Test plan

- [ ] Tag v0.34.0 after merge.
- [ ] Merge estabilis-platform v0.19.0 + tag.
- [ ] Cortex bump platform_revision + platform_gitops version + apply.
- [ ] Verify `cluster-secret-store` Application is emitted and produces `ClusterSecretStore/platform-secret-store` of provider `aws`.
- [ ] Verify `platform-secrets` Application transitions from Missing to Synced/Healthy once ExternalSecrets resolves against the new store.

## Azure impact

Zero. `provider` defaults to `azure`, existing template gate works unchanged.