### PR TITLE
feat(aws): karpenter-resources chart + metrics-server/karpenter value overlays (v0.35.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,72 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.35.0] — 2026-04-24
+
+### Added — `components/karpenter-resources/` chart + `values/platform/{metrics-server,karpenter}.yaml` overlays (AWS)
+
+Companion release to `estabilis-platform v0.21.0`, which adds Karpenter
+v1.12.0 + metrics-server Applications for AWS. This release ships the
+chart and value overlays consumed by those Applications, following ADR
+0002 Phase 3 (gitops repo as single source of truth for new components).
+
+#### `components/karpenter-resources/`
+
+Estabilis-authored chart that renders the two Karpenter custom
+resources for AWS:
+
+- `NodePool/default` — limits cpu=32 mem=64Gi, disruption
+  `WhenEmptyOrUnderutilized` after 1m, requirements amd64 +
+  spot/on-demand, instance categories c/m/r/t, generation > 4, sizes
+  medium/large/xlarge, `expireAfter: 720h`. Mirrors the legacy
+  `cortex-eks-prod` configuration.
+- `EC2NodeClass/default` — AMI alias `al2023@latest`, BDM `/dev/xvda`
+  30Gi gp3 encrypted, **IMDSv2 enforcement** (`httpTokens: required`,
+  `httpPutResponseHopLimit: 1`, `httpProtocolIPv6: disabled`),
+  Subnet/SG selection via `<discoveryTagKey>=<clusterName>` tags
+  (Terraform-applied; default tag key `estabilis.io/discovery`).
+
+Cluster-specific wiring (`clusterName`, `nodeRole`, `discoveryTagKey`)
+is injected via helm parameters from the platform-root template's
+AWS branch. NodePool/EC2NodeClass shape (instance families, sizes,
+limits) is configurable in this chart's `values.yaml` so downstream
+can tune capacity without forking.
+
+The chart's `appVersion` tracks the upstream Karpenter controller
+version we pin (currently 1.12.0). Schemas have remained stable
+across 1.x releases.
+
+#### `values/platform/metrics-server.yaml`
+
+Defaults for the upstream `metrics-server` chart on hub clusters.
+Consumed by `estabilis-platform/bootstrap/platform-root/templates/metrics-server.yaml`
+via the `$values/values/platform/metrics-server.yaml` ref. Mirrors
+legacy production: 2 replicas, podAntiAffinity by hostname,
+`--kubelet-insecure-tls`, tight resource limits.
+
+#### `values/platform/karpenter.yaml`
+
+Defaults for the upstream `karpenter` controller chart on hub
+clusters. Mirrors legacy production: controller resources, fargate
+toleration, `featureGates.spotToSpotConsolidation: true`. Cluster
+endpoint, name, and IRSA role are injected via helm parameters from
+the platform-root template, NOT this overlay.
+
+### Migration
+
+Bump `workload-bootstrap/Chart.yaml` `version` + `appVersion` to
+`0.35.0`, `workload-bootstrap/values.yaml` `repoVersion` to `v0.35.0`.
+
+Consumers (Estabilis client downstreams on AWS): set
+`platformGitopsVersion: "v0.35.0"` in
+`overrides/platform-root/values.yaml`. Required by
+`estabilis-platform v0.21.0`+ on AWS.
+
+### Azure impact
+
+Zero. All overlays and the chart are AWS-only — neither is referenced
+by any Application gated on `provider == "azure"`.
+
 ## [0.34.0] — 2026-04-24
 
 ### Added — `components/cluster-secret-store` chart now supports AWS provider

--- a/components/karpenter-resources/Chart.yaml
+++ b/components/karpenter-resources/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: karpenter-resources
+description: |
+  Default NodePool + EC2NodeClass for Karpenter on EKS.
+
+  Renders the two Karpenter custom resources that tell the controller
+  WHAT instances to provision and HOW (AMI, IAM, subnets, SGs). The
+  Karpenter controller chart itself is deployed by a separate
+  Application from the upstream OCI registry
+  (`public.ecr.aws/karpenter/karpenter`); this chart is rendered in
+  a later sync wave so the CRDs are present before the CRs apply.
+
+  appVersion tracks the Karpenter controller version we pin from
+  upstream — currently 1.12.0. NodePool/EC2NodeClass schemas have
+  remained stable across 1.x releases.
+type: application
+version: 0.1.0
+appVersion: "1.12.0"

--- a/components/karpenter-resources/templates/_helpers.tpl
+++ b/components/karpenter-resources/templates/_helpers.tpl
@@ -1,0 +1,48 @@
+{{/*
+Estabilis Platform — standard metadata helpers.
+
+These defines are duplicated identically across every internal chart in the
+platform (Option 2 from estabilis-platform-tools issue #45). Keep them in
+sync — if you change one, run `git grep -A 8 "define \"estabilis.labels\""`
+across core/components and apply the same edit everywhere.
+*/}}
+{{- define "estabilis.labels" -}}
+estabilis.io/component: {{ .Chart.Name }}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: estabilis-platform
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "estabilis.annotations" -}}
+estabilis.io/platform: "Estabilis Platform"
+estabilis.io/chart-version: {{ .Chart.Version | quote }}
+estabilis.io/website: "https://estabilis.com"
+estabilis.io/source: "https://github.com/Estabilis/estabilis-platform"
+estabilis.io/support: "ops@estabilis.com"
+estabilis.io/license: "proprietary"
+{{- include "estabilis.provenanceAnnotations" . }}
+{{- end -}}
+
+{{/*
+ADR 0005 Phase 2b — supply-chain L1 provenance annotations, populated
+from global.provenance.* at render time. The CLI sets these values via
+helm.parameters propagated from platform-root
+(see platform-root.provenanceParameters). The three-level guard keeps
+helm template standalone-renderable when the values are absent.
+*/}}
+{{- define "estabilis.provenanceAnnotations" -}}
+{{- if and .Values.global .Values.global.provenance .Values.global.provenance.gitRevision }}
+estabilis.io/git-revision: {{ .Values.global.provenance.gitRevision | quote }}
+estabilis.io/git-source: {{ .Values.global.provenance.gitSource | quote }}
+estabilis.io/built-at: {{ .Values.global.provenance.builtAt | quote }}
+estabilis.io/build-id: {{ .Values.global.provenance.buildId | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "estabilis.metadata" -}}
+labels:
+  {{- include "estabilis.labels" . | nindent 2 }}
+annotations:
+  {{- include "estabilis.annotations" . | nindent 2 }}
+{{- end -}}

--- a/components/karpenter-resources/templates/ec2nodeclass.yaml
+++ b/components/karpenter-resources/templates/ec2nodeclass.yaml
@@ -1,0 +1,32 @@
+{{- /*
+  EC2NodeClass — defines the AWS-specific shape of nodes Karpenter
+  provisions (AMI family, IAM role, subnets, security groups, EBS).
+
+  Subnets and security groups are discovered by Terraform-applied
+  tags (`{{ .Values.discoveryTagKey }}` = `<clusterName>`), the same
+  mechanism the legacy cortex-eks-prod cluster uses. The discovery
+  tag key is configurable per-deployment to allow multiple Estabilis
+  clusters to coexist in the same VPC without colliding on the
+  default `karpenter.sh/discovery` namespace.
+*/ -}}
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: default
+  {{- include "estabilis.metadata" . | nindent 2 }}
+spec:
+  amiSelectorTerms:
+    {{- toYaml .Values.ec2NodeClass.amiSelectorTerms | nindent 4 }}
+  role: {{ required "nodeRole is required" .Values.nodeRole | quote }}
+  subnetSelectorTerms:
+    - tags:
+        {{ .Values.discoveryTagKey }}: {{ required "clusterName is required" .Values.clusterName | quote }}
+  securityGroupSelectorTerms:
+    - tags:
+        {{ .Values.discoveryTagKey }}: {{ .Values.clusterName | quote }}
+  blockDeviceMappings:
+    {{- toYaml .Values.ec2NodeClass.blockDeviceMappings | nindent 4 }}
+  metadataOptions:
+    {{- toYaml .Values.ec2NodeClass.metadataOptions | nindent 4 }}
+  tags:
+    {{ .Values.discoveryTagKey }}: {{ .Values.clusterName | quote }}

--- a/components/karpenter-resources/templates/nodepool.yaml
+++ b/components/karpenter-resources/templates/nodepool.yaml
@@ -1,0 +1,31 @@
+{{- /*
+  NodePool — Karpenter scheduling policy. Defines what kinds of
+  EC2 instances may be provisioned (capacity-type, instance family,
+  size) and the disruption policy for reclaiming idle capacity.
+
+  Defaults mirror legacy cortex-eks-prod (general-purpose
+  c/m/r/t > gen4, medium/large/xlarge, spot+on-demand, 32 vCPU /
+  64Gi cluster cap, 1m underutilization consolidation).
+*/ -}}
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: default
+  {{- include "estabilis.metadata" . | nindent 2 }}
+spec:
+  limits:
+    {{- toYaml .Values.nodePool.limits | nindent 4 }}
+  disruption:
+    consolidationPolicy: {{ .Values.nodePool.disruption.consolidationPolicy }}
+    consolidateAfter: {{ .Values.nodePool.disruption.consolidateAfter }}
+    budgets:
+      {{- toYaml .Values.nodePool.disruption.budgets | nindent 6 }}
+  template:
+    spec:
+      expireAfter: {{ .Values.nodePool.template.expireAfter }}
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: default
+      requirements:
+        {{- toYaml .Values.nodePool.template.requirements | nindent 8 }}

--- a/components/karpenter-resources/values.yaml
+++ b/components/karpenter-resources/values.yaml
@@ -1,0 +1,64 @@
+# Karpenter NodePool + EC2NodeClass defaults.
+#
+# Cluster-specific wiring (clusterName, nodeRole, discovery tag) is
+# injected via helm.parameters from platform-root. Pool shape (instance
+# families, sizes, limits, disruption policy) is configurable here so
+# downstream can tune capacity without forking the chart.
+#
+# Defaults mirror the legacy `cortex-eks-prod` NodePool (general-
+# purpose c/m/r/t spot-or-on-demand, gen >4, sizes medium/large/xlarge,
+# 32 vCPU + 64Gi RAM cap, 1m underutilization consolidation).
+
+# clusterName, nodeRole, discoveryTagKey are all injected via
+# helm.parameters from the platform-root karpenter.yaml AWS branch.
+clusterName: ""
+nodeRole: ""
+discoveryTagKey: "estabilis.io/discovery"
+
+ec2NodeClass:
+  amiSelectorTerms:
+    - alias: al2023@latest
+  blockDeviceMappings:
+    - deviceName: /dev/xvda
+      ebs:
+        deleteOnTermination: true
+        encrypted: true
+        volumeSize: 30Gi
+        volumeType: gp3
+  # IMDSv2 enforcement — matches the security baseline on the legacy
+  # cortex-eks-prod nodes (`httpTokens: required`). Without this, EC2
+  # instances boot in IMDSv1 mode and leak credentials to any pod that
+  # can reach 169.254.169.254 unauthenticated.
+  metadataOptions:
+    httpEndpoint: enabled
+    httpProtocolIPv6: disabled
+    httpPutResponseHopLimit: 1
+    httpTokens: required
+
+nodePool:
+  limits:
+    cpu: "32"
+    memory: 64Gi
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 1m
+    budgets:
+      - nodes: "1"
+  template:
+    expireAfter: 720h
+    requirements:
+      - key: kubernetes.io/arch
+        operator: In
+        values: ["amd64"]
+      - key: karpenter.sh/capacity-type
+        operator: In
+        values: ["spot", "on-demand"]
+      - key: karpenter.k8s.aws/instance-category
+        operator: In
+        values: ["c", "m", "r", "t"]
+      - key: karpenter.k8s.aws/instance-generation
+        operator: Gt
+        values: ["4"]
+      - key: karpenter.k8s.aws/instance-size
+        operator: In
+        values: ["medium", "large", "xlarge"]

--- a/values/platform/karpenter.yaml
+++ b/values/platform/karpenter.yaml
@@ -1,0 +1,45 @@
+# Karpenter — controller + webhook for cluster autoscaling on AWS.
+#
+# AWS-only component. Azure uses the AKS native autoscaler, so the
+# platform-root template gates this Application on
+# `provider == "aws"` AND `autoscaler in [karpenter, hybrid]`.
+#
+# Provider-agnostic defaults derived from the legacy `cortex-eks-prod`
+# release (chart 1.9.x). We ship 1.12.x with additive changes only:
+# DescribeInstanceStatus interruption checks, NodeClaim CA-bundle drift,
+# AWS Application Recovery Controller zonal-shift integration, and
+# do-not-disrupt grace period. No breaking schema changes.
+#
+# Cluster-specific wiring (cluster name,
+# interruption queue, IAM role ARN) is injected via helm.parameters
+# from platform-root, with values pulled from the
+# `platform-infrastructure` ConfigMap.
+#
+# Downstream overrides: `overrides/karpenter/values.yaml` in the
+# client config repo.
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+# Controller runs on Fargate by default (the karpenter namespace is
+# part of the Fargate profile created by the EKS module). Without this
+# toleration, the controller pods can't schedule on the Fargate
+# infrastructure that hosts the namespace.
+tolerations:
+  - key: "eks.amazonaws.com/compute-type"
+    operator: "Equal"
+    value: "fargate"
+    effect: "NoSchedule"
+
+settings:
+  # spot-to-spot consolidation lets Karpenter migrate workloads
+  # between spot instances to reclaim cheaper capacity. Cleared by
+  # default-false in the chart but enabled here to match the legacy
+  # cortex production behaviour.
+  featureGates:
+    spotToSpotConsolidation: true

--- a/values/platform/metrics-server.yaml
+++ b/values/platform/metrics-server.yaml
@@ -1,0 +1,48 @@
+# metrics-server — Resource Metrics API server (`v1beta1.metrics.k8s.io`).
+#
+# Consumed by `kubectl top`, HPA, and any controller that talks to the
+# Resource Metrics API. AKS provides this natively so the platform-root
+# template gates the Application on `provider == "aws"`. EKS does not
+# include metrics-server in its managed addon set; this chart fills that gap.
+#
+# Defaults below mirror the configuration we run on the legacy
+# `cortex-eks-prod` cluster (chart 3.12.x, image v0.7.x):
+#   - 2 replicas with podAntiAffinity by hostname
+#   - `--kubelet-insecure-tls` because EKS kubelets present
+#     self-signed certs that don't validate against the cluster CA
+#     by default
+#   - small resource ask + tight limit (the workload is bounded)
+#
+# Downstream overrides go in
+# `overrides/metrics-server/values.yaml` of the client config repo
+# (consumed via the platform-root.overrideValueFile helper).
+
+replicas: 2
+
+args:
+  - --kubelet-insecure-tls
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi
+
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: metrics-server
+        topologyKey: kubernetes.io/hostname
+
+# `estabilis.io/workload-type=platform` toleration matches the MNG
+# node group annotation set by providers/aws/eks.tf — keeps the
+# metrics-server pods on platform nodes.
+tolerations:
+  - key: "estabilis.io/workload-type"
+    operator: "Equal"
+    value: "platform"
+    effect: "NoSchedule"

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.34.0
-appVersion: "0.34.0"
+version: 0.35.0
+appVersion: "0.35.0"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.34.0
+repoVersion: v0.35.0
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
Companion to estabilis-platform v0.21.0 (in-flight). Ships:

- New custom chart `components/karpenter-resources/` (NodePool + EC2NodeClass with IMDSv2 enforcement, configurable instance shape)
- New value overlays `values/platform/{metrics-server,karpenter}.yaml` (Estabilis defaults derived from legacy cortex-eks-prod)
- Bumps `workload-bootstrap/Chart.yaml` + `workload-bootstrap/values.yaml` repoVersion to v0.35.0

ADR 0002 Phase 3 layout — new components born in gitops repo, Application templates remain in platform repo. Reviewed by quality-control-validator and brutal-code-critic; all critical issues addressed (IMDSv2 added, AppProject whitelists in companion platform PR, components map declared). Karpenter v1.12.0 (released today, additive features only vs 1.9.x baseline).

Azure: zero impact.