### PR TITLE
fix: karpenter resources nested under controller.resources (v0.35.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,41 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.35.1] — 2026-04-25
+
+### Fixed — Karpenter `controller.resources` path (was top-level `resources`, silently ignored)
+
+The Karpenter chart (verified on both 1.9.x and 1.12.x) nests the
+controller container resources under `controller.resources` — NOT
+top-level `resources`. v0.35.0 of this repo had requests/limits at the
+top level, so when the platform-root karpenter Application rendered
+on cortex-eks-platform-prd, the chart silently dropped the values and
+the live Deployment shipped with `resources: {}`.
+
+Confirmed by reading `helm show values oci://public.ecr.aws/karpenter/karpenter`
+for both versions; the only `resources:` definition in the schema is
+indented under `controller:`.
+
+### Fix
+
+Re-nest under `controller.resources` and also bump to the values that
+match the legacy `cortex-eks-prod` LIVE Deployment (requests
+`500m / 1Gi`, limits `1 / 1Gi`) — the legacy `helm get values` output
+showed lower numbers (`250m / 500m / 512Mi`) at the wrong path,
+overridden by a manual patch later. We pin the actually-running
+configuration as the platform default.
+
+### Migration
+
+Operators on `v0.35.0` on AWS: bump `platformGitopsVersion` to
+`v0.35.1`, refresh + sync `karpenter` Application. Live Karpenter
+Deployment will roll its pods picking up the new requests/limits.
+No CRD changes; no impact on workloads scheduled by Karpenter.
+
+### Azure impact
+
+Zero — `karpenter` Application is gated on `provider == "aws"`.
+
 ## [0.35.0] — 2026-04-24
 
 ### Added — `components/karpenter-resources/` chart + `values/platform/{metrics-server,karpenter}.yaml` overlays (AWS)

--- a/values/platform/karpenter.yaml
+++ b/values/platform/karpenter.yaml
@@ -18,13 +18,26 @@
 # Downstream overrides: `overrides/karpenter/values.yaml` in the
 # client config repo.
 
-resources:
-  requests:
-    cpu: 250m
-    memory: 512Mi
-  limits:
-    cpu: 500m
-    memory: 512Mi
+controller:
+  # Resources for the controller container.
+  #
+  # The Karpenter chart nests resources under `controller.resources` —
+  # NOT top-level `resources`. v0.35.0 had the requests/limits at the
+  # wrong path so the chart silently rendered with `resources: {}` on
+  # cortex-eks-platform-prd. Verified via `helm show values` against
+  # both 1.9.x and 1.12.x: same path in both. The legacy
+  # `helm get values karpenter` on cortex-eks-prod showed top-level
+  # `resources:` (user-supplied at install time, also wrong path) — the
+  # actual live Deployment there has different resources from a manual
+  # patch later. We bake the correct path here and ship the values that
+  # match the legacy LIVE state.
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 1
+      memory: 1Gi
 
 # Controller runs on Fargate by default (the karpenter namespace is
 # part of the Fargate profile created by the EKS module). Without this

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.35.0
-appVersion: "0.35.0"
+version: 0.35.1
+appVersion: "0.35.1"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.35.0
+repoVersion: v0.35.1
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
v0.35.0 placed controller resources at top-level `resources:`. The Karpenter chart (1.9 and 1.12) nests under `controller.resources:` — values were silently dropped and live Deployment had `resources: {}`. Re-nested + matched the legacy cortex-eks-prod LIVE configuration.