### PR TITLE
feat(aws): aws-load-balancer-controller value overlay (v0.36.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,42 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.36.0] — 2026-04-25
+
+### Added — `values/platform/aws-load-balancer-controller.yaml`
+
+Companion to `estabilis-platform v0.23.0`, which adds the AWS Load
+Balancer Controller Application gated on
+`ingress_controller == "alb"`. This release ships the values overlay
+consumed by that Application via `$values/values/platform/aws-load-balancer-controller.yaml`.
+
+Defaults mirror the legacy `cortex-eks-prod` configuration (chart
+`1.17.1`, controller `v2.17.1`):
+- Resources: requests cpu=10m mem=64Mi / limits cpu=100m mem=128Mi
+- ServiceAccount created by the chart, IRSA role-arn injected via
+  helm.parameters from the platform-root template.
+- `podDisruptionBudget.maxUnavailable: 1` for the chart's default 2
+  replicas.
+
+`clusterName` and `vpcId` are NOT set in this overlay — they MUST be
+injected via helm.parameters from `platform-infrastructure` ConfigMap
+(`global.clusterName`, `global.vpcId`). Leaving them unset here makes
+the chart fail loud if a downstream forgets to wire them.
+
+### Migration
+
+Bump `workload-bootstrap/Chart.yaml` `version` + `appVersion` to
+`0.36.0`, `workload-bootstrap/values.yaml` `repoVersion` to `v0.36.0`.
+
+Consumers (Estabilis client downstreams on AWS adopting `alb` ingress):
+set `platformGitopsVersion: "v0.36.0"` in
+`overrides/platform-root/values.yaml`. Required by
+`estabilis-platform v0.23.0`+ when `ingress_controller = "alb"`.
+
+### Azure impact
+
+Zero. AWS-only overlay, never referenced by Azure-gated Applications.
+
 ## [0.35.1] — 2026-04-25
 
 ### Fixed — Karpenter `controller.resources` path (was top-level `resources`, silently ignored)

--- a/values/platform/aws-load-balancer-controller.yaml
+++ b/values/platform/aws-load-balancer-controller.yaml
@@ -1,0 +1,39 @@
+# AWS Load Balancer Controller — defaults for hub clusters.
+#
+# AWS-only component. Activated when `ingress_controller = "alb"` in
+# the platform downstream tfvars. The platform-root template
+# (`bootstrap/platform-root/templates/aws-load-balancer-controller.yaml`)
+# gates the Application accordingly.
+#
+# Defaults mirror the legacy `cortex-eks-prod` configuration (chart
+# 1.17.1, controller v2.17.1):
+#   - tight resources (10m / 64Mi req, 100m / 128Mi lim)
+#   - SA created by chart, IRSA role-arn injected via helm.parameters
+#     from platform-root using `global.identity.albController.roleArn`
+#   - clusterName + vpcId injected as helm.parameters as well
+#
+# Downstream overrides: `overrides/aws-load-balancer-controller/values.yaml`
+# in the client config repo.
+
+resources:
+  requests:
+    cpu: 10m
+    memory: 64Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi
+
+serviceAccount:
+  create: true
+  name: aws-load-balancer-controller
+
+automountServiceAccountToken: true
+
+# clusterName and vpcId are passed via helm.parameters from the
+# platform-root template — left empty here so the chart fails loud
+# (instead of silently provisioning ALBs against the wrong cluster).
+
+# Spread the two replicas the chart defaults to across nodes when
+# possible; matches the platform-wide policy on platform components.
+podDisruptionBudget:
+  maxUnavailable: 1

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.35.1
-appVersion: "0.35.1"
+version: 0.36.0
+appVersion: "0.36.0"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.35.1
+repoVersion: v0.36.0
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
Companion to estabilis-platform v0.23.0. Defaults mirror legacy cortex-eks-prod chart 1.17.1 / controller v2.17.1. AWS-only.