### PR TITLE
fix: cover aws-load-balancer-controller + karpenter in policy/quota layers (v0.37.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,74 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.37.0] — 2026-04-25
+
+### Added — `aws-load-balancer-controller` and `karpenter` namespaces in policy/quota coverage
+
+The `aws-load-balancer-controller` and `karpenter` namespaces were never
+listed in the platform's three exclusion/coverage layers, leaving them
+exposed to:
+- Kyverno background-generated `default-deny-all` NetworkPolicy from the
+  `default-deny-network-policy` ClusterPolicy (unconditional generate
+  rule, ignores the `kyverno.io/exclude` namespace label which only
+  affects admission webhooks).
+- `inject-pss-labels`, `require-limit-ranges`, `require-resource-quotas`
+  ClusterPolicies' Audit hits.
+- Zero `allow-*` NetworkPolicy compensating the deny-all (would block
+  AWS API egress on any cluster with NetworkPolicy enforcement enabled).
+- Zero `ResourceQuota` / `LimitRange` (no resource starvation guards).
+
+Today the live cortex-eks cluster is unaffected because EKS VPC CNI
+does not enforce NetworkPolicy by default and the Kyverno policies run
+in Audit mode. This release closes the gap proactively.
+
+#### Changes
+
+1. **`components/kyverno-policies/templates/_helpers.tpl`** — add
+   `aws-load-balancer-controller` and `karpenter` to the
+   `kyverno-policies.excluded-namespace-list` helper. Affects the four
+   ClusterPolicies that use it (`default-deny-network-policy`,
+   `inject-pss-labels`, `require-limit-ranges`, `require-resource-quotas`).
+2. **`components/network-policies/`** — declare both namespaces in the
+   `components` and `policies` maps + new `allow-aws-load-balancer-controller`
+   and `allow-karpenter` NetworkPolicy templates. Each allows broad egress
+   (AWS APIs over HTTPS + DNS + Kubernetes API), webhook callback ingress
+   on the chart's default port (9443 / 8443), and Alloy metrics scraping
+   from the `grafana` namespace.
+3. **`components/resource-quotas/`** — declare both namespaces in the
+   `components` and `namespaces` maps with quotas sized for the chart
+   defaults (ALB controller: 2 replicas × small footprint; karpenter:
+   2 replicas × moderate memory for cache).
+
+#### Provider-aware default-off (defensive)
+
+All three components default to `false` for `aws-load-balancer-controller`
+and `karpenter` in the chart values. The upstream platform-root
+forwarding template (>= v0.27.0, paired) only flips them to `true` on
+AWS deployments where the relevant feature flag is set
+(`ingress_controller=alb` for ALB controller, `autoscaler=karpenter|hybrid`
+for karpenter). On Azure the namespaces don't exist (Application
+templates are gated on `global.provider == "aws"`) and these toggles
+stay `false`, so this chart never tries to apply policies/quotas to
+non-existent namespaces.
+
+#### Pairing
+
+This release pairs with `estabilis-platform v0.27.0` which lands the
+filtered components forwarding in
+`bootstrap/platform-root/templates/network-policies.yaml` and
+`resource-quotas.yaml`. Operators bumping just one of the two:
+- `gitops v0.37.0` alone with `platform v0.26.x`: chart defaults
+  produce `false`, but upstream platform-root forwards `true` for these
+  components on every cluster regardless of provider, so the new
+  policies/quotas DO render — same outcome as before this release on
+  AWS, latent OutOfSync risk on Azure (workaround: explicit
+  `aws-load-balancer-controller: false, karpenter: false` in
+  `overrides/platform-root/values.yaml`).
+- `platform v0.27.0` alone with `gitops v0.36.1`: provider-aware
+  filter applies but the gitops chart never had ALB/karpenter coverage.
+  No regression.
+
 ## [0.36.1] — 2026-04-25
 
 ### Re-released as 0.36.1

--- a/components/kyverno-policies/templates/_helpers.tpl
+++ b/components/kyverno-policies/templates/_helpers.tpl
@@ -5,11 +5,13 @@ Do NOT call directly in policy templates — use the full exclude helpers.
 */}}
 {{- define "kyverno-policies.excluded-namespace-list" }}
                 - argocd
+                - aws-load-balancer-controller
                 - cert-manager
                 - cnpg-system
                 - external-dns
                 - external-secrets
                 - grafana
+                - karpenter
                 - kube-node-lease
                 - kube-public
                 - kube-state-metrics

--- a/components/network-policies/templates/policies.yaml
+++ b/components/network-policies/templates/policies.yaml
@@ -473,3 +473,72 @@ spec:
     # Kubernetes API (read policy results)
     - to: []
 {{- end }}
+---
+# =============================================================================
+# aws-load-balancer-controller namespace (AWS-only)
+# Needs broad egress: AWS APIs (ELB / EC2 / ACM / WAF / STS) over HTTPS
+# Ingress: webhook callbacks from API server (mutating + validating
+#          admission for Ingress / TargetGroupBinding / IngressClassParams)
+# =============================================================================
+{{- if and (index .Values.policies "aws-load-balancer-controller").enabled (ne (index .Values.components "aws-load-balancer-controller" | toString) "false") }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-aws-load-balancer-controller
+  namespace: aws-load-balancer-controller
+  {{- include "estabilis.metadata" . | nindent 2 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Webhook callbacks from API server (chart default port 9443)
+    - ports:
+        - protocol: TCP
+          port: 9443
+    # Metrics scraping from grafana namespace (Alloy)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: grafana
+  egress:
+{{ include "network-policies.dns-egress" . }}
+    # All egress (AWS APIs + Kubernetes API)
+    - to: []
+{{- end }}
+---
+# =============================================================================
+# karpenter namespace (AWS-only)
+# Needs broad egress: AWS APIs (EC2 / SQS / SSM / Pricing / STS) over HTTPS,
+#                     Kubernetes API (watch nodes/pods/nodepools)
+# Ingress: webhook callbacks from API server (NodePool / EC2NodeClass
+#          validating + mutating admission)
+# =============================================================================
+{{- if and (index .Values.policies "karpenter").enabled (ne (index .Values.components "karpenter" | toString) "false") }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-karpenter
+  namespace: karpenter
+  {{- include "estabilis.metadata" . | nindent 2 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Webhook callbacks from API server (chart default port 8443)
+    - ports:
+        - protocol: TCP
+          port: 8443
+    # Metrics scraping from grafana namespace (Alloy)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: grafana
+  egress:
+{{ include "network-policies.dns-egress" . }}
+    # All egress (AWS APIs + Kubernetes API)
+    - to: []
+{{- end }}

--- a/components/network-policies/values.yaml
+++ b/components/network-policies/values.yaml
@@ -30,6 +30,18 @@ components:
   kube-state-metrics: true
   node-exporter: true
   policy-reporter: true
+  # AWS-only components — DEFAULT FALSE on purpose (defensive).
+  # The platform-root Application templates (aws-load-balancer-controller.yaml
+  # and karpenter.yaml in the upstream platform repo) gate the Apps themselves
+  # on `global.provider == "aws"`, so the namespaces never come into existence
+  # on Azure. To avoid this chart rendering NetworkPolicies for non-existent
+  # namespaces, defaults are `false` here. The upstream platform-root
+  # forwarding template (>= v0.27.0) only flips them to `true` when provider
+  # = aws AND the relevant feature flag (ingress_controller=alb /
+  # autoscaler=karpenter|hybrid) matches. Operators on older platform
+  # versions or non-AWS clusters can leave these alone.
+  aws-load-balancer-controller: false
+  karpenter: false
 
 policies:
   grafana:
@@ -61,6 +73,10 @@ policies:
   node-exporter:
     enabled: true
   policy-reporter:
+    enabled: true
+  aws-load-balancer-controller:
+    enabled: true
+  karpenter:
     enabled: true
 
 # Downstream escape hatch — additive NetworkPolicies declared by the client.

--- a/components/resource-quotas/values.yaml
+++ b/components/resource-quotas/values.yaml
@@ -29,6 +29,15 @@ components:
   external-dns: true
   node-exporter: true
   kube-state-metrics: true
+  # AWS-only — DEFAULT FALSE on purpose.
+  # Same rationale as the network-policies chart: the upstream platform-root
+  # Application templates gate the Apps on `global.provider == "aws"`, so
+  # these namespaces don't exist on Azure. Defaults are `false` so this
+  # chart doesn't try to apply ResourceQuota / LimitRange to non-existent
+  # namespaces. Upstream platform-root (>= v0.27.0) only flips them to
+  # `true` on AWS deployments where the relevant feature flag is set.
+  aws-load-balancer-controller: false
+  karpenter: false
 
 defaults:
   hard:
@@ -178,5 +187,27 @@ namespaces:
       requests.memory: 512Mi
       limits.cpu: "2"
       limits.memory: 1Gi
+      pods: "10"
+      persistentvolumeclaims: "5"
+  # AWS-only — namespaces only exist on AWS clusters with the relevant
+  # feature flag (ingress_controller=alb for ALB controller, autoscaler=
+  # karpenter|hybrid for karpenter). Activated by `components.{ns}=true`
+  # forwarded by the upstream platform-root.
+  aws-load-balancer-controller:
+    enabled: true
+    hard:
+      requests.cpu: "500m"
+      requests.memory: 512Mi
+      limits.cpu: "2"
+      limits.memory: 1Gi
+      pods: "10"
+      persistentvolumeclaims: "5"
+  karpenter:
+    enabled: true
+    hard:
+      requests.cpu: "500m"
+      requests.memory: 1Gi
+      limits.cpu: "2"
+      limits.memory: 2Gi
       pods: "10"
       persistentvolumeclaims: "5"

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.36.1
-appVersion: "0.36.1"
+version: 0.37.0
+appVersion: "0.37.0"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.36.1
+repoVersion: v0.37.0
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
## Summary

Closes a triple-layered gap on `aws-load-balancer-controller` and `karpenter` namespaces — neither was listed in the platform's exclusion/coverage layers, leaving them exposed to:

- Kyverno background-generated `default-deny-all` NetworkPolicy from `default-deny-network-policy` ClusterPolicy. (The Kyverno admission webhook honors the `kyverno.io/exclude` namespace label; the **background generate controller does not** — different code path.)
- Audit hits from `inject-pss-labels`, `require-limit-ranges`, `require-resource-quotas`.
- Zero `allow-*` NetworkPolicy compensating the deny-all → would block AWS API egress on any cluster with NetworkPolicy enforcement enabled.
- Zero `ResourceQuota` / `LimitRange` → no resource starvation guard.

Today the live `eks-cortex-platform-prd-us-east-1` cluster is unaffected because EKS VPC CNI doesn't enforce NetworkPolicy by default and Kyverno runs in Audit mode. This release closes the gap before either flips on.

## Changes

| File | Change |
|---|---|
| `components/kyverno-policies/templates/_helpers.tpl` | Add `aws-load-balancer-controller` and `karpenter` to `excluded-namespace-list` (one place — affects 4 ClusterPolicies) |
| `components/network-policies/values.yaml` | Add to `components` + `policies` maps, default `false` |
| `components/network-policies/templates/policies.yaml` | New `allow-aws-load-balancer-controller` and `allow-karpenter` policy blocks |
| `components/resource-quotas/values.yaml` | Add to `components` + `namespaces` maps with chart-sized quotas, default `false` |
| `workload-bootstrap/Chart.yaml` | `version` + `appVersion` 0.36.1 → 0.37.0 |
| `workload-bootstrap/values.yaml` | `repoVersion` v0.36.1 → v0.37.0 |
| `CHANGELOG.md` | `[0.37.0]` entry |

## Provider-aware default-off (defensive)

The new `components.aws-load-balancer-controller` and `components.karpenter` default to **`false`** in chart values. They activate when the upstream `platform-root` template forwards them as `true`. Pairs with `estabilis-platform v0.27.0` which adds provider-aware filtering in `bootstrap/platform-root/templates/network-policies.yaml` and `resource-quotas.yaml` — on Azure these stay `false` (namespaces don't exist there because the ALB/karpenter Applications themselves are gated on `global.provider == "aws"`).

## Pairing matrix

| platform | gitops | Outcome on AWS | Outcome on Azure |
|---|---|---|---|
| v0.26.x | v0.36.1 (current) | gap stays | gap stays |
| **v0.26.x** | **v0.37.0 (this PR)** | new policies render (chart-default false but parent forces true) | new policies render for non-existent ns → OutOfSync drift unless override |
| v0.27.0 | v0.36.1 | platform forwards correctly but chart still has no ALB/karpenter coverage | no regression |
| **v0.27.0** | **v0.37.0** | new policies render correctly | provider filter blocks forwarding → namespaces stay default-false → no rendering ✅ |

## Test plan

- [x] Live cluster reproduction confirmed (default-deny-all in both ns from kyverno generate, no allow-* rules, no quotas)
- [ ] After merge + tag + cortex bump, `kubectl -n aws-load-balancer-controller get networkpolicy,resourcequota,limitrange` shows the new resources alongside the existing default-deny-all
- [ ] Same for `karpenter` namespace
- [ ] No regression on cert-manager / external-secrets / etc. (untouched)