### PR TITLE
fix(resource-quotas): bump karpenter quota to fit chart defaults (v0.37.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,41 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.37.1] — 2026-04-25
+
+### Fixed — `karpenter` ResourceQuota undersized for chart defaults
+
+`components/resource-quotas/values.yaml` shipped v0.37.0 with a
+karpenter quota of `requests.cpu=500m, requests.memory=1Gi` based on
+a back-of-envelope sizing. The actual karpenter chart defaults
+(per pod) are `requests.cpu=500m, requests.memory=1Gi`, and the
+chart deploys 2 replicas — so the steady-state consumption already
+exceeds the quota out of the box (2 × 1Gi = 2Gi memory > 1Gi quota).
+
+Live cortex-eks observation:
+```
+requests.cpu:    1/500m    (2 pods × 500m = 1 CPU)
+requests.memory: 2Gi/1Gi   (2 pods × 1Gi = 2Gi)
+```
+
+Existing pods continue running (Kubernetes does not retroactively
+evict over-quota pods), but new pods would be denied — including
+rollout surges and OOMKill replacements.
+
+#### Fix
+
+Bumped quota to give 50% headroom over steady state for safe rolling
+updates (3 pods during surge):
+```
+requests.cpu:    500m  → 1500m
+requests.memory: 1Gi   → 3Gi
+limits.cpu:      2     → 4
+limits.memory:   2Gi   → 4Gi
+```
+ALB controller quota is unchanged — its chart defaults
+(`requests.cpu=10m, requests.memory=64Mi`) leave the v0.37.0 quota
+generous already (live: 20m/500m, 128Mi/512Mi).
+
 ## [0.37.0] — 2026-04-25
 
 ### Added — `aws-load-balancer-controller` and `karpenter` namespaces in policy/quota coverage

--- a/components/resource-quotas/values.yaml
+++ b/components/resource-quotas/values.yaml
@@ -204,10 +204,13 @@ namespaces:
       persistentvolumeclaims: "5"
   karpenter:
     enabled: true
+    # Sized for the karpenter chart defaults: 2 replicas × 500m CPU + 1Gi
+    # memory each (requests). Quota gives 50% headroom over the steady
+    # state to allow rolling updates (3 pods briefly during surge).
     hard:
-      requests.cpu: "500m"
-      requests.memory: 1Gi
-      limits.cpu: "2"
-      limits.memory: 2Gi
+      requests.cpu: "1500m"
+      requests.memory: 3Gi
+      limits.cpu: "4"
+      limits.memory: 4Gi
       pods: "10"
       persistentvolumeclaims: "5"

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.37.0
-appVersion: "0.37.0"
+version: 0.37.1
+appVersion: "0.37.1"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.37.0
+repoVersion: v0.37.1
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
## Summary

Patch follow-up to v0.37.0. Karpenter quota was undersized for the chart's actual defaults — observed live on cortex-eks immediately after v0.37.0 deployment:

```
requests.cpu:    1/500m    (2 pods × 500m = 1 CPU steady state vs 500m quota)
requests.memory: 2Gi/1Gi   (2 pods × 1Gi = 2Gi steady state vs 1Gi quota)
```

Existing pods kept running (no retroactive eviction), but new pods would be blocked — including rolling-update surges (3 pods briefly) and OOMKill replacements.

## Fix

Bumped to give 50% headroom over steady state:

| Field | v0.37.0 | v0.37.1 |
|---|---|---|
| requests.cpu | 500m | **1500m** |
| requests.memory | 1Gi | **3Gi** |
| limits.cpu | 2 | **4** |
| limits.memory | 2Gi | **4Gi** |

ALB controller quota unchanged — its chart defaults (`requests.cpu=10m, requests.memory=64Mi`) leave v0.37.0's quota generous (live: 20m/500m, 128Mi/512Mi).

## Test plan

- [x] Live measurements confirm karpenter pods at 500m/1Gi requests each, 2 replicas
- [ ] After v0.37.1 + cortex bump, `kubectl -n karpenter describe resourcequota` shows used < hard for all dimensions