### PR TITLE
fix: cover metrics-server in policy/quota layers (v0.37.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,45 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.37.2] — 2026-04-25
+
+### Added — `metrics-server` namespace coverage in policy/quota layers
+
+Audit follow-up to v0.37.1: `metrics-server` (AWS-only — Azure AKS
+ships it natively) had the same triple-layer gap that
+`aws-load-balancer-controller` and `karpenter` had before v0.37.0:
+- Not in `excluded-namespace-list` → Kyverno generated `default-deny-all`
+- Not in `network-policies` `components` / `policies` → no `allow-*`
+- Not in `resource-quotas` `components` / `namespaces` → no quota / limit
+
+Live cortex-eks observation prior to this fix:
+```
+$ kubectl -n metrics-server get networkpolicy,resourcequota,limitrange
+NAME               POD-SELECTOR   AGE
+default-deny-all   <none>         13h    ← only Kyverno-generated, no compensating allow
+```
+
+#### Changes
+
+1. **`components/kyverno-policies/templates/_helpers.tpl`** — add
+   `metrics-server` to `excluded-namespace-list` (alphabetically between
+   `kyverno` and `node-exporter`).
+2. **`components/network-policies/`** — declare `metrics-server` in
+   `components` (default `false`) + `policies` map + new
+   `allow-metrics-server` template. Allows kubelet egress (port 10250)
+   for resource metrics scrape, broad egress for cluster IP, ingress
+   from API server on chart default port 4443 (aggregated /apis/metrics.k8s.io)
+   and from grafana namespace for Alloy scraping.
+3. **`components/resource-quotas/`** — declare `metrics-server` in
+   `components` (default `false`) + `namespaces` map. Sized for chart
+   default of 2 HA replicas × 100m/200Mi (requests): hard
+   `requests.cpu=300m, requests.memory=600Mi, limits.cpu=1, limits.memory=1Gi`.
+
+The upstream platform-root provider-aware filter (introduced in
+`estabilis-platform v0.27.0`) already includes `metrics-server` in the
+`awsOnly` list, so on Azure these stay `false` and the chart skips
+rendering for the non-existent namespace.
+
 ## [0.37.1] — 2026-04-25
 
 ### Fixed — `karpenter` ResourceQuota undersized for chart defaults

--- a/components/kyverno-policies/templates/_helpers.tpl
+++ b/components/kyverno-policies/templates/_helpers.tpl
@@ -17,6 +17,7 @@ Do NOT call directly in policy templates — use the full exclude helpers.
                 - kube-state-metrics
                 - kube-system
                 - kyverno
+                - metrics-server
                 - node-exporter
                 - opencost
                 - traefik

--- a/components/network-policies/templates/policies.yaml
+++ b/components/network-policies/templates/policies.yaml
@@ -542,3 +542,39 @@ spec:
     # All egress (AWS APIs + Kubernetes API)
     - to: []
 {{- end }}
+---
+# =============================================================================
+# metrics-server namespace (AWS-only — Azure AKS provides metrics-server natively)
+# Needs egress: kubelet on every node (port 10250) for resource metrics
+#               + Kubernetes API for the aggregated /apis/metrics.k8s.io
+# Ingress: API server requests through the aggregated API (port 4443 by default)
+#          + Alloy metrics scraping
+# =============================================================================
+{{- if and (index .Values.policies "metrics-server").enabled (ne (index .Values.components "metrics-server" | toString) "false") }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-metrics-server
+  namespace: metrics-server
+  {{- include "estabilis.metadata" . | nindent 2 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # API server -> metrics-server aggregated API (chart default port 4443)
+    - ports:
+        - protocol: TCP
+          port: 4443
+    # Metrics scraping from grafana namespace (Alloy)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: grafana
+  egress:
+{{ include "network-policies.dns-egress" . }}
+    # Kubelet on every node (port 10250) — required for resource metrics scrape.
+    # Also covers Kubernetes API (cluster IP) for the aggregated API registration.
+    - to: []
+{{- end }}

--- a/components/network-policies/values.yaml
+++ b/components/network-policies/values.yaml
@@ -31,17 +31,19 @@ components:
   node-exporter: true
   policy-reporter: true
   # AWS-only components — DEFAULT FALSE on purpose (defensive).
-  # The platform-root Application templates (aws-load-balancer-controller.yaml
-  # and karpenter.yaml in the upstream platform repo) gate the Apps themselves
-  # on `global.provider == "aws"`, so the namespaces never come into existence
-  # on Azure. To avoid this chart rendering NetworkPolicies for non-existent
-  # namespaces, defaults are `false` here. The upstream platform-root
-  # forwarding template (>= v0.27.0) only flips them to `true` when provider
-  # = aws AND the relevant feature flag (ingress_controller=alb /
-  # autoscaler=karpenter|hybrid) matches. Operators on older platform
-  # versions or non-AWS clusters can leave these alone.
+  # The platform-root Application templates (aws-load-balancer-controller.yaml,
+  # karpenter.yaml, metrics-server.yaml in the upstream platform repo) gate
+  # the Apps themselves on `global.provider == "aws"`, so the namespaces
+  # never come into existence on Azure. To avoid this chart rendering
+  # NetworkPolicies for non-existent namespaces, defaults are `false` here.
+  # The upstream platform-root forwarding template (>= v0.27.0) only flips
+  # them to `true` when provider = aws AND the relevant feature flag matches
+  # (ingress_controller=alb for ALB controller, autoscaler=karpenter|hybrid
+  # for karpenter; metrics-server is unconditional on AWS — Azure AKS provides
+  # natively).
   aws-load-balancer-controller: false
   karpenter: false
+  metrics-server: false
 
 policies:
   grafana:
@@ -77,6 +79,8 @@ policies:
   aws-load-balancer-controller:
     enabled: true
   karpenter:
+    enabled: true
+  metrics-server:
     enabled: true
 
 # Downstream escape hatch — additive NetworkPolicies declared by the client.

--- a/components/resource-quotas/values.yaml
+++ b/components/resource-quotas/values.yaml
@@ -35,9 +35,11 @@ components:
   # these namespaces don't exist on Azure. Defaults are `false` so this
   # chart doesn't try to apply ResourceQuota / LimitRange to non-existent
   # namespaces. Upstream platform-root (>= v0.27.0) only flips them to
-  # `true` on AWS deployments where the relevant feature flag is set.
+  # `true` on AWS deployments where the relevant feature flag is set
+  # (metrics-server is unconditional on AWS — Azure AKS ships it natively).
   aws-load-balancer-controller: false
   karpenter: false
+  metrics-server: false
 
 defaults:
   hard:
@@ -212,5 +214,16 @@ namespaces:
       requests.memory: 3Gi
       limits.cpu: "4"
       limits.memory: 4Gi
+      pods: "10"
+      persistentvolumeclaims: "5"
+  metrics-server:
+    enabled: true
+    # Sized for chart defaults: 2 replicas (HA) × 100m CPU + 200Mi memory
+    # each (requests). Quota gives 50% headroom for rolling-update surges.
+    hard:
+      requests.cpu: "300m"
+      requests.memory: 600Mi
+      limits.cpu: "1"
+      limits.memory: 1Gi
       pods: "10"
       persistentvolumeclaims: "5"

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.37.1
-appVersion: "0.37.1"
+version: 0.37.2
+appVersion: "0.37.2"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.37.1
+repoVersion: v0.37.2
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
Audit follow-up to v0.37.1 — `metrics-server` (AWS-only) had the same triple-layer gap that ALB/karpenter had pre-v0.37.0. Live observation: only `default-deny-all` (Kyverno-generated), no compensating allow-*, no ResourceQuota, no LimitRange.

Same fix pattern: helper exclusion + network-policy + quota. Provider-aware filter in platform-root (`>= v0.27.0`) already covers metrics-server in the `awsOnly` list, so Azure stays auto-off.

## Test plan

- [x] Live audit confirms gap (only default-deny-all NP, no quota)
- [ ] After v0.37.2 + cortex bump, `kubectl -n metrics-server get networkpolicy,resourcequota,limitrange` shows allow-metrics-server + quota + limit-range