### PR TITLE
feat: vault namespace coverage in policy/quota layers (v0.38.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,51 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.38.0] — 2026-04-25
+
+### Added — `vault` namespace coverage in policy/quota layers (foundation)
+
+First pass of HashiCorp Vault as a multi-provider platform component.
+This release lands ONLY the policy/quota coverage (triple-belt) for
+the `vault` namespace; the chart values overlay, Terraform
+infrastructure, and platform-root Application live in
+`estabilis-platform v0.28.0` (paired).
+
+#### Changes
+
+1. **`components/kyverno-policies/templates/_helpers.tpl`** — add
+   `vault` to `excluded-namespace-list` (alphabetically last). Affects
+   the four ClusterPolicies that use this helper
+   (`default-deny-network-policy`, `inject-pss-labels`,
+   `require-limit-ranges`, `require-resource-quotas`).
+2. **`components/network-policies/`** — declare `vault` in `components`
+   and `policies` maps (default `false`) + new `allow-vault` template.
+   Allows broad egress (cloud unseal endpoint — KMS / Azure Key Vault,
+   backup storage — S3 / Azure Storage, Kubernetes API), inter-pod
+   Raft on port 8201, ingress on Vault API port 8200 from any pod
+   (Vault is the cluster-scoped secret store), and Alloy metrics
+   scraping from `grafana` namespace.
+3. **`components/resource-quotas/`** — declare `vault` in `components`
+   and `namespaces` maps (default `false`). Sized for 3-replica Raft HA
+   at chart defaults (50m/128Mi requests, 250m/256Mi limits per pod):
+   hard `requests.cpu=300m, requests.memory=600Mi, limits.cpu=1500m,
+   limits.memory=1500Mi`. PVC count = 5 (3 Raft replicas with headroom).
+
+#### Foundation scope
+
+This release is part of the Vault foundation — chart deployment +
+provider-aware unseal infrastructure only. Bootstrap (auth methods,
+policies, KV mount, ClusterSecretStore wiring) is intentionally
+deferred to downstream / follow-up releases. Vault comes up sealed
+or auto-unsealed (depending on cloud unseal status) but
+NOT-INITIALIZED — operator runs `vault operator init` manually after
+the platform-root Application syncs.
+
+The `vault: false` default in both charts pairs with the upstream
+`bootstrap/platform-root/values.yaml` default of `vault: false` —
+opt-in feature, activated by `vault_enabled = true` in
+terraform.tfvars.
+
 ## [0.37.2] — 2026-04-25
 
 ### Added — `metrics-server` namespace coverage in policy/quota layers

--- a/components/kyverno-policies/templates/_helpers.tpl
+++ b/components/kyverno-policies/templates/_helpers.tpl
@@ -19,6 +19,7 @@ Do NOT call directly in policy templates — use the full exclude helpers.
                 - kyverno
                 - metrics-server
                 - node-exporter
+                - vault
                 - opencost
                 - traefik
                 - trivy-system

--- a/components/network-policies/templates/policies.yaml
+++ b/components/network-policies/templates/policies.yaml
@@ -544,6 +544,63 @@ spec:
 {{- end }}
 ---
 # =============================================================================
+# vault namespace (multi-provider — auto-unseal AWS KMS / Azure Key Vault)
+# Egress: cloud unseal endpoint (KMS / Key Vault), backup storage (S3 /
+#         Azure Storage), Kubernetes API (service-registration), inter-pod
+#         Raft cluster traffic on port 8201.
+# Ingress: Vault API (port 8200) from anywhere on the cluster (Vault is
+#          a cluster-scoped secret store), inter-pod Raft on 8201,
+#          Alloy metrics scraping from grafana namespace.
+# =============================================================================
+{{- if and (index .Values.policies "vault").enabled (ne (index .Values.components "vault" | toString) "false") }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-vault
+  namespace: vault
+  {{- include "estabilis.metadata" . | nindent 2 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Vault API from any pod in the cluster (Vault is the cluster-scoped
+    # secret store; clients in any namespace must reach it on 8200).
+    - ports:
+        - protocol: TCP
+          port: 8200
+    # Inter-pod Raft cluster traffic on 8201 (HA quorum + log replication)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: vault
+      ports:
+        - protocol: TCP
+          port: 8201
+    # Metrics scraping from grafana namespace (Alloy → /v1/sys/metrics)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: grafana
+      ports:
+        - protocol: TCP
+          port: 8200
+  egress:
+{{ include "network-policies.dns-egress" . }}
+    # Inter-pod Raft (egress side)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: vault
+      ports:
+        - protocol: TCP
+          port: 8201
+    # All egress (cloud unseal API, backup storage, Kubernetes API)
+    - to: []
+{{- end }}
+---
+# =============================================================================
 # metrics-server namespace (AWS-only — Azure AKS provides metrics-server natively)
 # Needs egress: kubelet on every node (port 10250) for resource metrics
 #               + Kubernetes API for the aggregated /apis/metrics.k8s.io

--- a/components/network-policies/values.yaml
+++ b/components/network-policies/values.yaml
@@ -45,6 +45,12 @@ components:
   karpenter: false
   metrics-server: false
 
+  # Multi-provider opt-in components — DEFAULT FALSE.
+  # Vault is opt-in on either provider via `vault_enabled = true` in
+  # terraform.tfvars. Auto-unseal differs per provider (AWS KMS / Azure
+  # Key Vault) but the chart and triple-belt are identical.
+  vault: false
+
 policies:
   grafana:
     enabled: true
@@ -81,6 +87,8 @@ policies:
   karpenter:
     enabled: true
   metrics-server:
+    enabled: true
+  vault:
     enabled: true
 
 # Downstream escape hatch — additive NetworkPolicies declared by the client.

--- a/components/resource-quotas/values.yaml
+++ b/components/resource-quotas/values.yaml
@@ -41,6 +41,10 @@ components:
   karpenter: false
   metrics-server: false
 
+  # Multi-provider opt-in — DEFAULT FALSE. Activated when
+  # vault_enabled = true in terraform.tfvars.
+  vault: false
+
 defaults:
   hard:
     requests.cpu: "1"
@@ -225,5 +229,18 @@ namespaces:
       requests.memory: 600Mi
       limits.cpu: "1"
       limits.memory: 1Gi
+      pods: "10"
+      persistentvolumeclaims: "5"
+  vault:
+    enabled: true
+    # Sized for 3-replica Raft HA at chart defaults (50m/128Mi requests,
+    # 250m/256Mi limits per pod). 50% headroom over steady state for
+    # rolling-update surges (4 pods briefly).
+    # PVC count = 3 (one per Raft replica, gp3/Premium_LRS).
+    hard:
+      requests.cpu: "300m"
+      requests.memory: 600Mi
+      limits.cpu: "1500m"
+      limits.memory: 1500Mi
       pods: "10"
       persistentvolumeclaims: "5"

--- a/values/platform/vault-aws.yaml
+++ b/values/platform/vault-aws.yaml
@@ -1,0 +1,62 @@
+# AWS-specific overlay for HashiCorp Vault.
+# Loaded in addition to vault.yaml when global.provider=aws.
+#
+# Auto-unseal: AWS KMS via `seal "awskms"` stanza in the Raft HCL config.
+# Identity: IRSA — the SA gets annotated with the IAM role ARN provisioned
+# by `providers/aws/vault.tf` → module.vault_irsa. Role grants:
+#   - kms:Encrypt / kms:Decrypt / kms:DescribeKey on the dedicated unseal key
+#   - s3:PutObject / s3:GetObject / s3:ListBucket on the snapshot bucket
+#
+# The `kms_key_id` and `region` placeholders below are replaced by helm
+# parameters injected by `bootstrap/platform-root/templates/vault.yaml`
+# from the `platform-infrastructure-sensitive` Secret (terraform-managed).
+
+server:
+  # PVC storage class — gp3 default on EKS clusters.
+  dataStorage:
+    storageClass: gp3
+
+  # IRSA annotation — role ARN injected via helm.parameters from
+  # platform-root (`server.serviceAccount.annotations.eks\.amazonaws\.com/role-arn`).
+  serviceAccount:
+    create: true
+
+  ha:
+    raft:
+      # Provider-specific Raft + seal config.
+      # ${vault_kms_key_id} and ${vault_kms_region} are replaced by helm
+      # parameters from platform-root.
+      config: |
+        ui = true
+
+        listener "tcp" {
+          tls_disable     = 1
+          address         = "[::]:8200"
+          cluster_address = "[::]:8201"
+        }
+
+        storage "raft" {
+          path = "/vault/data"
+
+          retry_join {
+            leader_api_addr = "http://vault-0.vault-internal:8200"
+          }
+          retry_join {
+            leader_api_addr = "http://vault-1.vault-internal:8200"
+          }
+          retry_join {
+            leader_api_addr = "http://vault-2.vault-internal:8200"
+          }
+        }
+
+        seal "awskms" {
+          region     = "VAULT_KMS_REGION_PLACEHOLDER"
+          kms_key_id = "VAULT_KMS_KEY_ID_PLACEHOLDER"
+        }
+
+        telemetry {
+          prometheus_retention_time = "24h"
+          disable_hostname          = true
+        }
+
+        service_registration "kubernetes" {}

--- a/values/platform/vault-azure.yaml
+++ b/values/platform/vault-azure.yaml
@@ -1,0 +1,71 @@
+# Azure-specific overlay for HashiCorp Vault.
+# Loaded in addition to vault.yaml when global.provider=azure.
+#
+# Auto-unseal: Azure Key Vault via `seal "azurekeyvault"` stanza.
+# Identity: Workload Identity — the SA gets annotated with the dedicated
+# Managed Identity client ID provisioned by `providers/azure/vault.tf`.
+# The MI has these role assignments:
+#   - Key Vault Crypto User on the dedicated KV (encrypt/decrypt/wrap/unwrap)
+#   - Storage Blob Data Contributor on the snapshot Storage Account
+#
+# Placeholder strings below are replaced by helm parameters injected by
+# `bootstrap/platform-root/templates/vault.yaml` from the
+# `platform-infrastructure-sensitive` Secret (terraform-managed).
+
+server:
+  # PVC storage class — managed-csi default on AKS (Premium_LRS).
+  dataStorage:
+    storageClass: managed-csi
+
+  # Workload Identity annotation — client_id injected via helm.parameters
+  # from platform-root (`server.serviceAccount.annotations.azure\.workload\.identity/client-id`).
+  serviceAccount:
+    create: true
+
+  # Pod-level Workload Identity label
+  statefulSet:
+    annotations: {}
+  extraLabels:
+    azure.workload.identity/use: "true"
+
+  ha:
+    raft:
+      # Provider-specific Raft + seal config.
+      # VAULT_KEY_VAULT_NAME_PLACEHOLDER, VAULT_UNSEAL_KEY_NAME_PLACEHOLDER,
+      # VAULT_TENANT_ID_PLACEHOLDER are replaced by helm parameters from
+      # platform-root.
+      config: |
+        ui = true
+
+        listener "tcp" {
+          tls_disable     = 1
+          address         = "[::]:8200"
+          cluster_address = "[::]:8201"
+        }
+
+        storage "raft" {
+          path = "/vault/data"
+
+          retry_join {
+            leader_api_addr = "http://vault-0.vault-internal:8200"
+          }
+          retry_join {
+            leader_api_addr = "http://vault-1.vault-internal:8200"
+          }
+          retry_join {
+            leader_api_addr = "http://vault-2.vault-internal:8200"
+          }
+        }
+
+        seal "azurekeyvault" {
+          tenant_id  = "VAULT_TENANT_ID_PLACEHOLDER"
+          vault_name = "VAULT_KEY_VAULT_NAME_PLACEHOLDER"
+          key_name   = "VAULT_UNSEAL_KEY_NAME_PLACEHOLDER"
+        }
+
+        telemetry {
+          prometheus_retention_time = "24h"
+          disable_hostname          = true
+        }
+
+        service_registration "kubernetes" {}

--- a/values/platform/vault.yaml
+++ b/values/platform/vault.yaml
@@ -1,0 +1,82 @@
+# Provider-agnostic value overlay for HashiCorp Vault (chart `vault` 0.29.x).
+#
+# Loaded by `bootstrap/platform-root/templates/vault.yaml` Application as
+# `$values/values/platform/vault.yaml`. Provider-specific extensions
+# (auto-unseal `seal` stanza, ServiceAccount IRSA / Workload Identity
+# annotations) live in `vault-aws.yaml` / `vault-azure.yaml`.
+#
+# Foundation scope: chart deployment + 3-replica Raft HA + cloud auto-unseal
+# only. Bootstrap (auth methods, policies, KV mount, ClusterSecretStore
+# wiring) is intentionally deferred to follow-up releases. Vault comes up
+# sealed/auto-unsealed (depending on cloud unseal config) but
+# NOT-INITIALIZED. Operator runs `vault operator init` manually after the
+# Application syncs.
+
+# --- Global overlay metadata ---
+commonLabels:
+  estabilis.io/component: vault
+  estabilis.io/managed-by: platform
+
+# --- Sidecar injector OFF ---
+# We use ESO (or future direct-Vault clients) — never Vault Agent injection.
+# Disabling avoids an unnecessary mutating webhook and shaves the surface for
+# admission timeouts.
+injector:
+  enabled: false
+
+server:
+  # 3 replicas, real Raft quorum (one pod per node enforced via affinity).
+  replicas: 3
+
+  # Disable the post-install test job. It runs `vault status` but KMS / KV
+  # unseal may not have completed at job time, producing a false negative
+  # and helm rollback. Vault readiness is verified by the readiness probes
+  # the chart already configures.
+  tests:
+    enabled: false
+
+  # Conservative resource floor; tune via downstream override.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi
+
+  # Force one pod per node — Raft needs real quorum, not 3 pods on one node.
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: vault
+              component: server
+          topologyKey: kubernetes.io/hostname
+
+  # Persistent Raft data — 10Gi per replica.
+  dataStorage:
+    enabled: true
+    size: 10Gi
+    # storageClass overridden per-provider (gp3 on AWS, default on Azure).
+
+  # Standalone mode OFF — we run HA Raft.
+  standalone:
+    enabled: false
+
+  ha:
+    enabled: true
+    replicas: 3
+    raft:
+      enabled: true
+      setNodeId: true
+      # `config` is overridden in vault-aws.yaml / vault-azure.yaml to
+      # inject the provider-specific `seal` stanza. The base shape (listener,
+      # storage, telemetry, service_registration) is identical across
+      # providers.
+
+# --- UI ---
+# Top-level chart key, NOT under server. Nesting it would silently no-op.
+ui:
+  enabled: true
+  serviceType: ClusterIP

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.37.2
-appVersion: "0.37.2"
+version: 0.38.0
+appVersion: "0.38.0"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.37.2
+repoVersion: v0.38.0
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
Foundation pass for HashiCorp Vault as a multi-provider platform component (AWS + Azure). This release lands ONLY the triple-belt coverage entries; the chart values overlay, Terraform infrastructure, and platform-root Application live in `estabilis-platform v0.28.0` (paired).

## Changes

- `_helpers.tpl` — add `vault` to `excluded-namespace-list` (affects 4 ClusterPolicies using `platform-exclude-*` helpers).
- `components/network-policies/` — declare `vault` in components+policies (default `false`) + `allow-vault` template:
  - Broad egress (cloud unseal: KMS/Azure KV; backup storage: S3/Azure Storage; Kubernetes API)
  - Inter-pod Raft cluster traffic on port 8201
  - Ingress on Vault API 8200 from any pod (cluster-scoped secret store)
  - Alloy metrics scraping from `grafana` namespace on 8200
- `components/resource-quotas/` — declare `vault` in components+namespaces (default `false`). Sized for 3-replica Raft HA at chart defaults: `requests.cpu=300m, requests.memory=600Mi, limits.cpu=1500m, limits.memory=1500Mi`, PVC=5.

## Foundation scope (not in this PR — paired or deferred)

- ❌ Bootstrap (auth, policies, KV mount, ClusterSecretStore) — deferred
- ❌ Vault chart values overlay — `estabilis-platform v0.28.0`
- ❌ Terraform KMS/KV/Storage backup infra — `estabilis-platform v0.28.0`
- ❌ Vault operator init — manual after platform-root sync

Defaults `vault: false` in both charts pair with upstream `bootstrap/platform-root/values.yaml` default of `vault: false` — opt-in feature.