### PR TITLE
fix(vault): clean up overlays — drop dead placeholders + gp3 default (v0.38.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.38.1] — 2026-04-25
+
+### Fixed — Vault chart overlays cleaned up (no more dead-code placeholders, no more gp3 default)
+
+Companion to `estabilis-platform v0.28.2` which lands the `vault-ingress`
+chart. v0.38.0's overlays carried two issues exposed during the cortex
+deployment:
+
+#### `values/platform/vault-aws.yaml` & `vault-azure.yaml`
+
+- **Removed placeholder strings** (`VAULT_KMS_REGION_PLACEHOLDER`,
+  `VAULT_KMS_KEY_ID_PLACEHOLDER`, `VAULT_TENANT_ID_PLACEHOLDER`, etc.)
+  inside the `server.ha.raft.config` block. The platform-root template
+  in `bootstrap/platform-root/templates/vault.yaml` injects the entire
+  `server.ha.raft.config` value via `--set` from helm.parameters,
+  completely overriding any value set in these overlay files. The
+  placeholders were dead code — confusing and never substituted.
+
+- **`server.dataStorage.storageClass` default changed `gp3` → `""`**
+  (use the cluster's default StorageClass). Older EKS clusters ship
+  only the legacy in-tree `gp2` provisioner without the EBS CSI driver;
+  hardcoding `gp3` blocked PVC binding on those. Clusters that have
+  `gp3` available can override per-client via `overrides/vault/values.yaml`.
+
+These overlay files now carry only the bits NOT handled via helm
+parameter — `serviceAccount.create: true`, the `azure.workload.identity/use`
+label for Azure, and the (now-empty) `storageClass`.
+
 ## [0.38.0] — 2026-04-25
 
 ### Added — `vault` namespace coverage in policy/quota layers (foundation)

--- a/values/platform/vault-aws.yaml
+++ b/values/platform/vault-aws.yaml
@@ -2,61 +2,22 @@
 # Loaded in addition to vault.yaml when global.provider=aws.
 #
 # Auto-unseal: AWS KMS via `seal "awskms"` stanza in the Raft HCL config.
-# Identity: IRSA — the SA gets annotated with the IAM role ARN provisioned
-# by `providers/aws/vault.tf` → module.vault_irsa. Role grants:
-#   - kms:Encrypt / kms:Decrypt / kms:DescribeKey on the dedicated unseal key
-#   - s3:PutObject / s3:GetObject / s3:ListBucket on the snapshot bucket
-#
-# The `kms_key_id` and `region` placeholders below are replaced by helm
-# parameters injected by `bootstrap/platform-root/templates/vault.yaml`
-# from the `platform-infrastructure-sensitive` Secret (terraform-managed).
+# The full `server.ha.raft.config` block is INJECTED via helm.parameters by
+# `bootstrap/platform-root/templates/vault.yaml` (see the AWS branch
+# there). This file only carries the bits that are NOT handled via
+# helm parameter — provider-specific defaults that are convenient to
+# express as a values overlay.
 
 server:
-  # PVC storage class — gp3 default on EKS clusters.
+  # PVC storage class — empty default so the cluster's default
+  # StorageClass is used. Older EKS clusters ship only the legacy in-tree
+  # `gp2` provisioner; modern EKS with the EBS CSI driver typically has
+  # `gp3` available. Override per cluster via the client repo's
+  # `overrides/vault/values.yaml`.
   dataStorage:
-    storageClass: gp3
+    storageClass: ""
 
-  # IRSA annotation — role ARN injected via helm.parameters from
-  # platform-root (`server.serviceAccount.annotations.eks\.amazonaws\.com/role-arn`).
+  # IRSA annotation is injected via helm.parameters from platform-root
+  # (`server.serviceAccount.annotations.eks\.amazonaws\.com/role-arn`).
   serviceAccount:
     create: true
-
-  ha:
-    raft:
-      # Provider-specific Raft + seal config.
-      # ${vault_kms_key_id} and ${vault_kms_region} are replaced by helm
-      # parameters from platform-root.
-      config: |
-        ui = true
-
-        listener "tcp" {
-          tls_disable     = 1
-          address         = "[::]:8200"
-          cluster_address = "[::]:8201"
-        }
-
-        storage "raft" {
-          path = "/vault/data"
-
-          retry_join {
-            leader_api_addr = "http://vault-0.vault-internal:8200"
-          }
-          retry_join {
-            leader_api_addr = "http://vault-1.vault-internal:8200"
-          }
-          retry_join {
-            leader_api_addr = "http://vault-2.vault-internal:8200"
-          }
-        }
-
-        seal "awskms" {
-          region     = "VAULT_KMS_REGION_PLACEHOLDER"
-          kms_key_id = "VAULT_KMS_KEY_ID_PLACEHOLDER"
-        }
-
-        telemetry {
-          prometheus_retention_time = "24h"
-          disable_hostname          = true
-        }
-
-        service_registration "kubernetes" {}

--- a/values/platform/vault-azure.yaml
+++ b/values/platform/vault-azure.yaml
@@ -2,70 +2,23 @@
 # Loaded in addition to vault.yaml when global.provider=azure.
 #
 # Auto-unseal: Azure Key Vault via `seal "azurekeyvault"` stanza.
-# Identity: Workload Identity — the SA gets annotated with the dedicated
-# Managed Identity client ID provisioned by `providers/azure/vault.tf`.
-# The MI has these role assignments:
-#   - Key Vault Crypto User on the dedicated KV (encrypt/decrypt/wrap/unwrap)
-#   - Storage Blob Data Contributor on the snapshot Storage Account
-#
-# Placeholder strings below are replaced by helm parameters injected by
-# `bootstrap/platform-root/templates/vault.yaml` from the
-# `platform-infrastructure-sensitive` Secret (terraform-managed).
+# The full `server.ha.raft.config` block is INJECTED via helm.parameters by
+# `bootstrap/platform-root/templates/vault.yaml` (see the Azure branch
+# there). This file only carries the bits that are NOT handled via
+# helm parameter.
 
 server:
-  # PVC storage class — managed-csi default on AKS (Premium_LRS).
+  # PVC storage class — empty default so the cluster's default
+  # StorageClass is used. AKS typically ships `default` (Premium_LRS via
+  # azure-disk-csi). Override per cluster if needed.
   dataStorage:
-    storageClass: managed-csi
+    storageClass: ""
 
-  # Workload Identity annotation — client_id injected via helm.parameters
-  # from platform-root (`server.serviceAccount.annotations.azure\.workload\.identity/client-id`).
+  # Workload Identity annotation is injected via helm.parameters from
+  # platform-root (`server.serviceAccount.annotations.azure\.workload\.identity/client-id`).
   serviceAccount:
     create: true
 
   # Pod-level Workload Identity label
-  statefulSet:
-    annotations: {}
   extraLabels:
     azure.workload.identity/use: "true"
-
-  ha:
-    raft:
-      # Provider-specific Raft + seal config.
-      # VAULT_KEY_VAULT_NAME_PLACEHOLDER, VAULT_UNSEAL_KEY_NAME_PLACEHOLDER,
-      # VAULT_TENANT_ID_PLACEHOLDER are replaced by helm parameters from
-      # platform-root.
-      config: |
-        ui = true
-
-        listener "tcp" {
-          tls_disable     = 1
-          address         = "[::]:8200"
-          cluster_address = "[::]:8201"
-        }
-
-        storage "raft" {
-          path = "/vault/data"
-
-          retry_join {
-            leader_api_addr = "http://vault-0.vault-internal:8200"
-          }
-          retry_join {
-            leader_api_addr = "http://vault-1.vault-internal:8200"
-          }
-          retry_join {
-            leader_api_addr = "http://vault-2.vault-internal:8200"
-          }
-        }
-
-        seal "azurekeyvault" {
-          tenant_id  = "VAULT_TENANT_ID_PLACEHOLDER"
-          vault_name = "VAULT_KEY_VAULT_NAME_PLACEHOLDER"
-          key_name   = "VAULT_UNSEAL_KEY_NAME_PLACEHOLDER"
-        }
-
-        telemetry {
-          prometheus_retention_time = "24h"
-          disable_hostname          = true
-        }
-
-        service_registration "kubernetes" {}

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.38.0
-appVersion: "0.38.0"
+version: 0.38.1
+appVersion: "0.38.1"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.38.0
+repoVersion: v0.38.1
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
Companion patch to estabilis-platform v0.28.2 (vault-ingress chart). Cleans v0.38.0 overlays:

- Removed placeholder strings inside server.ha.raft.config — platform-root template injects the full block via --set, so the values file content was dead code.
- dataStorage.storageClass: gp3 → `""` (use cluster default). Avoids breaking on EKS clusters without the EBS CSI driver.