### PR TITLE
feat(vault-ingress): migrate chart from estabilis-platform per ADR 0002 (v0.38.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,38 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.38.2] — 2026-04-26
+
+### Added — `components/vault-ingress/` (migrated from platform repo per ADR 0002)
+
+The `vault-ingress` chart was originally created in
+`estabilis-platform/core/components/vault-ingress/` (v0.28.2). Per
+ADR 0002 (gitops chart consolidation, Phase 3 target), all platform
+component charts must live in this repo, with the platform repo
+keeping only the bootstrap Application templates that reference them.
+
+This release moves the chart to its correct home before any client
+takes a hard dependency on the legacy path.
+
+#### Changes
+
+- **NEW**: `components/vault-ingress/` (Chart.yaml, values.yaml,
+  templates/_helpers.tpl, templates/middleware.yaml). Byte-identical
+  copy of what shipped in `estabilis-platform v0.28.2`.
+- The platform repo's `bootstrap/platform-root/templates/vault-ingress.yaml`
+  is updated in `estabilis-platform v0.28.3` (paired) to reference the
+  new path: `repoURL: estabilis-platform-gitops.git` + `path: components/vault-ingress`.
+
+#### Migration
+
+For clusters running `estabilis-platform v0.28.2`:
+- Bump platform to `v0.28.3` (paired with this release). The
+  Application's source repoURL changes from platform to gitops; ArgoCD
+  handles the source change transparently — same chart content, no
+  pod restart, no Ingress recreation.
+
+For deployments not yet using Vault: no-op.
+
 ## [0.38.1] — 2026-04-25
 
 ### Fixed — Vault chart overlays cleaned up (no more dead-code placeholders, no more gp3 default)

--- a/components/vault-ingress/Chart.yaml
+++ b/components/vault-ingress/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: vault-ingress
+description: HashiCorp Vault external ingress — ADR 0014 multi-exposure model (mirror of grafana-ingress, vault-specific backend + healthcheck)
+version: 0.1.0
+appVersion: "0.1.0"
+type: application

--- a/components/vault-ingress/templates/_helpers.tpl
+++ b/components/vault-ingress/templates/_helpers.tpl
@@ -1,0 +1,33 @@
+{{/*
+Mirror of the platform-wide estabilis metadata helpers (ADR 0003).
+Duplicated identically across internal charts; keep in sync.
+*/}}
+{{- define "estabilis.labels" -}}
+estabilis.io/component: {{ .Chart.Name }}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: estabilis-platform
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "estabilis.annotations" -}}
+estabilis.io/platform: "Estabilis Platform"
+estabilis.io/chart-version: {{ .Chart.Version | quote }}
+estabilis.io/website: "https://estabilis.com"
+estabilis.io/source: "https://github.com/Estabilis/estabilis-platform"
+estabilis.io/support: "ops@estabilis.com"
+estabilis.io/license: "proprietary"
+{{- if and .Values.global .Values.global.provenance .Values.global.provenance.gitRevision }}
+estabilis.io/git-revision: {{ .Values.global.provenance.gitRevision | quote }}
+estabilis.io/git-source: {{ .Values.global.provenance.gitSource | quote }}
+estabilis.io/built-at: {{ .Values.global.provenance.builtAt | quote }}
+estabilis.io/build-id: {{ .Values.global.provenance.buildId | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "estabilis.metadata" -}}
+labels:
+  {{- include "estabilis.labels" . | nindent 2 }}
+annotations:
+  {{- include "estabilis.annotations" . | nindent 2 }}
+{{- end -}}

--- a/components/vault-ingress/templates/middleware.yaml
+++ b/components/vault-ingress/templates/middleware.yaml
@@ -1,0 +1,226 @@
+{{- /*
+  ADR 0014 — one Ingress (+ Middlewares for Traefik / + ALB annotations
+  for AWS) per enabled exposure profile.
+
+  Backend: vault-ui (port 8200) in the vault namespace. All
+  resources live in the vault namespace to share Traefik's cross-namespace
+  Middleware reference capability (Traefik path) or to keep the
+  Ingress co-located with the backend Service (ALB path).
+
+  The chart branches on `$exp.ingress_class`:
+    - "traefik" / "traefik-internal" → Traefik IngressRoute pattern
+      with Middlewares for ipAllowList. basic_auth is NOT supported
+      (Vault has its own UI auth — would double-auth) and the chart
+      fails loud if a profile sets it.
+    - "alb" → AWS Load Balancer Controller pattern with
+      `alb.ingress.kubernetes.io/*` annotations.
+
+  Default healthcheck path tuned for Vault: `/v1/sys/health?standbyok=true
+  &sealedcode=200&uninitcode=200`. The flags keep the LB routing traffic
+  to standby pods (default would 429), to sealed pods (so the operator
+  can reach the API to unseal), and to uninitialized pods (so the
+  operator can hit `vault operator init` via the LB).
+*/ -}}
+{{- $raw := .Values.exposuresJson | default "{}" -}}
+{{- $jsonStr := $raw -}}
+{{- if and $raw (not (or (hasPrefix "{" $raw) (hasPrefix "[" $raw))) }}
+  {{- $jsonStr = b64dec $raw }}
+{{- end }}
+{{- $exposures := fromJson $jsonStr -}}
+{{- range $profile, $exp := $exposures }}
+{{- if $exp.enabled }}
+{{- $isALB := eq $exp.ingress_class "alb" }}
+
+{{- /* Vault has its own UI authentication — basic_auth would double-auth.
+       Fail loud regardless of ingress class. */}}
+{{- if $exp.basic_auth }}
+{{- fail (printf "vault_exposures.%s: basic_auth=true is not supported (Vault has its own UI auth — basic_auth would double-auth)." $profile) }}
+{{- end }}
+
+{{- if and $isALB (eq $exp.alb_certificate_source "acm") (eq (default "" $.Values.global.acmCertificateArn) "") }}
+{{- fail (printf "vault_exposures.%s: alb_certificate_source=acm but global.acmCertificateArn is empty. Set acm_enabled=true on the platform Terraform module so an ACM cert is provisioned and its ARN auto-flows to this chart, or pick a different alb_certificate_source." $profile) }}
+{{- end }}
+
+{{- if and $isALB (not (has $exp.alb_certificate_source (list "acm" "cert-manager"))) }}
+{{- fail (printf "vault_exposures.%s: alb_certificate_source=%q is not recognized. Valid values: 'acm' (recommended — ALB Controller consumes ACM cert directly), 'cert-manager' (NOT supported by stock ALB Controller — kept for forward compatibility with future syncer integrations)." $profile $exp.alb_certificate_source) }}
+{{- end }}
+
+{{- if $isALB }}
+{{- /* ============================ ALB BRANCH ============================ */}}
+{{- $hcPath := default "/v1/sys/health?standbyok=true&sealedcode=200&uninitcode=200" $exp.alb_healthcheck_path }}
+{{- $useACM := eq $exp.alb_certificate_source "acm" }}
+---
+{{- if not $useACM }}
+{{- /* cert-manager Certificate (DNS-01 issued); ALB references via Ingress TLS spec */}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: vault-{{ $profile }}-tls
+  namespace: vault
+  {{- include "estabilis.metadata" $ | nindent 2 }}
+spec:
+  secretName: vault-{{ $profile }}-tls
+  issuerRef:
+    name: {{ $exp.issuer | default "letsencrypt-production" | quote }}
+    kind: ClusterIssuer
+  dnsNames:
+    - {{ $exp.host | quote }}
+---
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: vault-{{ $profile }}
+  namespace: vault
+  {{- include "estabilis.metadata" $ | nindent 2 }}
+  annotations:
+    {{- /* Core ALB annotations */}}
+    alb.ingress.kubernetes.io/scheme: {{ $exp.alb_scheme | quote }}
+    alb.ingress.kubernetes.io/target-type: {{ $exp.alb_target_type | quote }}
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/ssl-policy: {{ $exp.alb_ssl_policy | quote }}
+    alb.ingress.kubernetes.io/healthcheck-path: {{ $hcPath | quote }}
+    {{- /* Group routes multiple Ingresses behind ONE shared ALB —
+          significant cost saver when several apps are exposed. */}}
+    alb.ingress.kubernetes.io/group.name: {{ $exp.alb_group | quote }}
+    {{- if $useACM }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ $.Values.global.acmCertificateArn | quote }}
+    {{- end }}
+    {{- if $exp.allowed_cidrs }}
+    {{- /* ALB listener-rule condition (per-service). Restricts source IPs
+          at the listener level — different mechanism from Traefik
+          Middlewares but equivalent end result. */}}
+    alb.ingress.kubernetes.io/conditions.vault-ui: |-
+      [{"field":"source-ip","sourceIpConfig":{"values":[{{- $cidrs := list -}}{{- range splitList "," $exp.allowed_cidrs -}}{{- $cidrs = append $cidrs (printf "%q" (trim .)) -}}{{- end -}}{{ join "," $cidrs }}]}}]
+    {{- end }}
+    {{- if hasKey $.Values.global "dnsProvider" }}
+    {{- if eq $.Values.global.dnsProvider "cloudflare" }}
+    {{- /* Cloudflare DNS-only mode (orange cloud OFF) — preserves real
+          ALB IP for source-IP allowlist to work. With proxy ON, every
+          request appears to originate from Cloudflare CIDRs. */}}
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: {{ $exp.alb_cloudflare_proxied | quote }}
+    {{- end }}
+    {{- end }}
+    external-dns.alpha.kubernetes.io/hostname: {{ $exp.host | quote }}
+spec:
+  ingressClassName: alb
+  rules:
+    - host: {{ $exp.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: vault-ui
+                port:
+                  number: 8200
+  {{- if not $useACM }}
+  tls:
+    - secretName: vault-{{ $profile }}-tls
+      hosts:
+        - {{ $exp.host | quote }}
+  {{- end }}
+{{- else }}
+{{- /* ========================== TRAEFIK BRANCH ========================== */}}
+{{- $mwIPName := printf "vault-%s-ipallowlist" $profile }}
+{{- $mwAuthName := printf "vault-%s-auth" $profile }}
+---
+{{- if $exp.allowed_cidrs }}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ $mwIPName }}
+  namespace: vault
+  {{- include "estabilis.metadata" $ | nindent 2 }}
+spec:
+  ipAllowList:
+    sourceRange:
+      {{- range splitList "," $exp.allowed_cidrs }}
+      - {{ trim . | quote }}
+      {{- end }}
+---
+{{- end }}
+{{- if $exp.basic_auth }}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ $mwAuthName }}
+  namespace: vault
+  {{- include "estabilis.metadata" $ | nindent 2 }}
+spec:
+  basicAuth:
+    secret: {{ $mwAuthName }}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ $mwAuthName }}
+  namespace: vault
+  {{- include "estabilis.metadata" $ | nindent 2 }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: platform-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: {{ $mwAuthName }}
+    creationPolicy: Owner
+  data:
+    - secretKey: users
+      remoteRef:
+        key: {{ printf "%s-%s" $.Values.kvSecretPrefix $profile | quote }}
+---
+{{- end }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: vault-{{ $profile }}-tls
+  namespace: vault
+  {{- include "estabilis.metadata" $ | nindent 2 }}
+spec:
+  secretName: vault-{{ $profile }}-tls
+  issuerRef:
+    name: {{ $exp.issuer | default "letsencrypt-production" | quote }}
+    kind: ClusterIssuer
+  dnsNames:
+    - {{ $exp.host | quote }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: vault-{{ $profile }}
+  namespace: vault
+  {{- include "estabilis.metadata" $ | nindent 2 }}
+  annotations:
+    {{- $mws := list }}
+    {{- if $exp.allowed_cidrs }}
+    {{- $mws = append $mws (printf "vault-%s@kubernetescrd" $mwIPName) }}
+    {{- end }}
+    {{- if $exp.basic_auth }}
+    {{- $mws = append $mws (printf "vault-%s@kubernetescrd" $mwAuthName) }}
+    {{- end }}
+    {{- if $mws }}
+    traefik.ingress.kubernetes.io/router.middlewares: {{ join "," $mws | quote }}
+    {{- end }}
+    external-dns.alpha.kubernetes.io/hostname: {{ $exp.host | quote }}
+spec:
+  ingressClassName: {{ $exp.ingress_class | default "traefik" | quote }}
+  rules:
+    - host: {{ $exp.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: vault-ui
+                port:
+                  number: 8200
+  tls:
+    - secretName: vault-{{ $profile }}-tls
+      hosts:
+        - {{ $exp.host | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/components/vault-ingress/values.yaml
+++ b/components/vault-ingress/values.yaml
@@ -1,0 +1,27 @@
+# HashiCorp Vault external ingress — ADR 0014 (multi-exposure model).
+#
+# Mirror of grafana-ingress/values.yaml. Each entry in exposures becomes a
+# K8s Ingress (+ Middlewares for Traefik / + ALB annotations for AWS) +
+# optional cert-manager Certificate. The Ingress points at the `vault-ui`
+# Service on port 8200 (the Vault chart's UI service).
+#
+# Vault has its own UI authentication — `basic_auth` is unsupported
+# (would double-auth) and the chart fails loud if a profile sets it.
+
+# Injected by platform-root as a JSON string parameter from
+# `vault.exposuresJson` in the platform-infrastructure-sensitive Secret.
+# Source of truth: `var.vault_exposures` in providers/{aws,azure}/variables.tf
+# resolved via `local.vault_exposures_resolved` in providers/*/main.tf.
+exposuresJson: "{}"
+
+# Default Vault health-check path consumed when an exposure profile leaves
+# `alb_healthcheck_path` empty. `standbyok=true` returns 200 from standby
+# pods (default would 429); `sealedcode=200` + `uninitcode=200` keep the
+# LB routing traffic to a fresh Vault that hasn't been initialized yet —
+# operator can run `vault operator init` via the LB.
+defaultHealthcheckPath: "/v1/sys/health?standbyok=true&sealedcode=200&uninitcode=200"
+
+# `global` block populated by helm.parameters from platform-root.
+global:
+  acmCertificateArn: ""
+  dnsProvider: ""

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.38.1
-appVersion: "0.38.1"
+version: 0.38.2
+appVersion: "0.38.2"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.38.1
+repoVersion: v0.38.2
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
ADR 0002 Phase 3 target — all platform component charts live in this repo. `vault-ingress` was created in `estabilis-platform/core/components/vault-ingress/` in v0.28.2 (wrong location); migrating byte-identical before any client takes a hard dependency on the legacy path.

## Pairs with platform PR

[Estabilis/estabilis-platform#111](https://github.com/Estabilis/estabilis-platform/pull/111) (v0.28.3) — deletes platform-side chart copy + updates Application template to source from this repo.

## Test plan

- [x] Files copied byte-identical from estabilis-platform/core/components/vault-ingress/
- [ ] After merge + tag + cortex bump, vault-ingress App's repoURL transitions transparently from platform to gitops; no pod restart, no Ingress recreation