### PR TITLE
fix(network-policies): allow-metrics-server port 4443→10250 (v0.39.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,47 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.39.1] — 2026-04-29
+
+### Fixed — `allow-metrics-server` NetworkPolicy port mismatch (AWS-only)
+
+The `allow-metrics-server` NetworkPolicy in `components/network-policies/templates/policies.yaml`
+hardcoded `port: 4443` for ingress traffic from the API server. The
+upstream metrics-server helm chart consumed by
+`estabilis-platform/bootstrap/platform-root/templates/metrics-server.yaml`
+serves the aggregated API on **port 10250** (`--secure-port=10250` in
+the deployment args; matches `containerPort.https`). With the policy
+restricting ingress to a port the pod did not listen on, the API
+server's discovery probe to `v1beta1.metrics.k8s.io` failed with
+`context deadline exceeded`, leaving the APIService stuck at
+`Available: False (FailedDiscoveryCheck)` and breaking `kubectl top`,
+HPA, and any controller that reads the Resource Metrics API.
+
+This bug affects **AWS deployments only**. Azure (AKS) clusters provide
+metrics-server natively as part of the managed control plane, so the
+NetworkPolicy is gated off (`components.metrics-server: false` and the
+metrics-server Application is also AWS-only via
+`{{ if eq .Values.global.provider "aws" }}`).
+
+The bug was introduced in v0.37.2 (commit `a9f3d6a` —
+`fix: cover metrics-server namespace in policy/quota layers`). Until
+the cortex-platform-aws-us-east-1-prd upstart on 2026-04-29, no AWS
+PRD environment had run both metrics-server (Wave 2) and network-policies
+(Wave 15) end-to-end, so the regression went unnoticed.
+
+Fix:
+
+- `components/network-policies/templates/policies.yaml` line 626:
+  `port: 4443` → `port: 10250`
+- Updated inline comments on lines 607 and 623 to reflect the chart's
+  actual port and document why this block must track the chart.
+
+### Files
+
+- `components/network-policies/templates/policies.yaml`
+- `workload-bootstrap/Chart.yaml` (`version` + `appVersion` → 0.39.1)
+- `workload-bootstrap/values.yaml` (`repoVersion` → v0.39.1)
+
 ## [0.39.0] — 2026-04-28
 
 ### Changed — `client-apps` ApplicationSet aligns with ADR 0027 taxonomy v2

--- a/components/network-policies/templates/policies.yaml
+++ b/components/network-policies/templates/policies.yaml
@@ -604,7 +604,7 @@ spec:
 # metrics-server namespace (AWS-only — Azure AKS provides metrics-server natively)
 # Needs egress: kubelet on every node (port 10250) for resource metrics
 #               + Kubernetes API for the aggregated /apis/metrics.k8s.io
-# Ingress: API server requests through the aggregated API (port 4443 by default)
+# Ingress: API server requests through the aggregated API (port 10250)
 #          + Alloy metrics scraping
 # =============================================================================
 {{- if and (index .Values.policies "metrics-server").enabled (ne (index .Values.components "metrics-server" | toString) "false") }}
@@ -620,10 +620,14 @@ spec:
     - Ingress
     - Egress
   ingress:
-    # API server -> metrics-server aggregated API (chart default port 4443)
+    # API server -> metrics-server aggregated API. The metrics-server chart
+    # exposes the aggregated API on port 10250 (set via --secure-port=10250
+    # in the deployment args; matches containerPort.https). Earlier chart
+    # versions defaulted to 4443 — this block hardcoded 4443 historically
+    # and must track the chart's actual port.
     - ports:
         - protocol: TCP
-          port: 4443
+          port: 10250
     # Metrics scraping from grafana namespace (Alloy)
     - from:
         - namespaceSelector:

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.39.0
-appVersion: "0.39.0"
+version: 0.39.1
+appVersion: "0.39.1"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.39.0
+repoVersion: v0.39.1
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
## Summary

The `allow-metrics-server` NetworkPolicy in `components/network-policies/templates/policies.yaml` hardcoded `port: 4443` for ingress traffic from the API server, but the upstream `metrics-server` helm chart serves the aggregated API on **port 10250** (`--secure-port=10250`). With the policy restricting ingress to a port the pod did not listen on, the API server's discovery probe to `v1beta1.metrics.k8s.io` failed with `context deadline exceeded` → APIService `Available=False (FailedDiscoveryCheck)` → `kubectl top` / HPA broken.

**AWS-only**. AKS provides metrics-server natively, so the NP is gated off in Azure.

## Root cause

Bug introduced in v0.37.2 (commit `a9f3d6a`, `fix: cover metrics-server namespace in policy/quota layers`). The hardcoded `4443` was the chart default in older versions; the current chart uses `10250`. First observed during the cortex-platform-aws-us-east-1-prd upstart on 2026-04-29 — no prior AWS PRD had run both metrics-server (Wave 2) and network-policies (Wave 15) end-to-end.

## Fix

- `components/network-policies/templates/policies.yaml` line 626: `port: 4443` → `port: 10250`
- Updated inline comments (lines 607 and 623) to track the chart's actual port and document why this block must follow the chart.
- `workload-bootstrap/Chart.yaml` (`version` + `appVersion` → 0.39.1)
- `workload-bootstrap/values.yaml` (`repoVersion` → v0.39.1)
- `CHANGELOG.md`: new `[0.39.1]` section

## Test plan

- [x] Patched the NP manually on the live cortex prd cluster — APIService transitioned `Available=False` → `Available=True` within seconds.
- [ ] After merge + release tag, propagate via:
  - `estabilis-platform` bump `platformGitopsVersion` → `v0.39.1` (release `v0.36.1`)
  - cortex wrapper `overrides/platform-root/values.yaml` bump (release `v1.15.2`)
  - `terraform apply` + `estabilis promote`