### PR TITLE
feat(cert-manager-config): universal selfsigned ClusterIssuer (v0.39.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,36 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.39.2] — 2026-04-30
+
+### Added — Universal `selfsigned` ClusterIssuer in `cert-manager-config`
+
+`components/cert-manager-config/templates/cluster-issuer-selfsigned.yaml`:
+new universal ClusterIssuer named `selfsigned` (cert-manager.io/v1,
+type SelfSigned). Created unconditionally — applies to both Azure and
+AWS deployments — because the use cases (admission webhook certs,
+internal mTLS, bootstrap CAs) are provider-agnostic and don't require
+ACME/DNS validation.
+
+Canonical first consumer: `external-secrets` chart's
+`webhook.certManager.cert.issuerRef` in `estabilis-platform >= v0.36.3`.
+Without this issuer the chart cannot enable cert-manager mode for the
+webhook cert, and falls back to its bundled cert-controller which
+fights ArgoCD's ServerSideApply on the cluster-scoped
+ValidatingWebhookConfiguration (full diagnosis in
+`estabilis-platform-tools/docs/runbooks/cortex/cortex-aws-prd-upstart-cli-mirror.md`
+Wave 3 postmortem).
+
+Other components can reuse the same issuer for any internal cert that
+doesn't need a publicly-validated chain.
+
+### Files
+
+- `components/cert-manager-config/templates/cluster-issuer-selfsigned.yaml` (NEW)
+- `workload-bootstrap/Chart.yaml` (`version` + `appVersion` → 0.39.2)
+- `workload-bootstrap/values.yaml` (`repoVersion` → v0.39.2)
+- `CHANGELOG.md` (this entry)
+
 ## [0.39.1] — 2026-04-29
 
 ### Fixed — `allow-metrics-server` NetworkPolicy port mismatch (AWS-only)

--- a/components/cert-manager-config/templates/cluster-issuer-selfsigned.yaml
+++ b/components/cert-manager-config/templates/cluster-issuer-selfsigned.yaml
@@ -1,0 +1,25 @@
+{{- /*
+Universal SelfSigned ClusterIssuer for in-cluster TLS where ACME is not
+applicable (admission webhook certs, internal mTLS, bootstrap CAs).
+
+Created unconditionally because both Azure and AWS have at least one
+component (external-secrets webhook) that benefits from delegating cert
+management to cert-manager + cainjector instead of the chart's bundled
+cert-controller — which uses Update operations and races with ArgoCD's
+ServerSideApply on the cluster-scoped ValidatingWebhookConfiguration.
+
+Consumers reference this via `webhook.certManager.cert.issuerRef`:
+  kind: ClusterIssuer
+  name: selfsigned
+
+See estabilis-platform external-secrets.yaml template (>= v0.36.3) for
+the canonical consumer pattern, and ADR / postmortem
+2026-04-30 cortex prd for the full diagnosis.
+*/}}
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned
+  {{- include "estabilis.metadata" . | nindent 2 }}
+spec:
+  selfSigned: {}

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.39.1
-appVersion: "0.39.1"
+version: 0.39.2
+appVersion: "0.39.2"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.39.1
+repoVersion: v0.39.2
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
## Summary

Adds a universal `selfsigned` ClusterIssuer to `cert-manager-config` for use by any platform component that needs an in-cluster CA where ACME isn't applicable.

## Why

Cortex prd 2026-04-30 postmortem: external-secrets chart's bundled cert-controller does `Update` (full PUT) operations on the cluster-scoped ValidatingWebhookConfiguration, racing ArgoCD's ServerSideApply at 50+ ResourceVersion increments/second. The chart supports a `webhook.certManager.enabled=true` mode that disables the bundled cert-controller and delegates webhook cert management to cert-manager + cainjector (uses SSA, no race) — but requires an Issuer the chart can reference. This adds it.

Companion estabilis-platform PR (separate) flips ESO chart to use this issuer.

## Files

- `components/cert-manager-config/templates/cluster-issuer-selfsigned.yaml` (NEW, ~10 LOC)
- `workload-bootstrap/Chart.yaml`: 0.39.1 → 0.39.2
- `workload-bootstrap/values.yaml`: repoVersion → v0.39.2
- `CHANGELOG.md`: [0.39.2] entry

## Test plan

- [ ] After merge + auto-tag → bump consumed in estabilis-platform v0.36.3
- [ ] On cortex prd cluster, verify `kubectl get clusterissuer selfsigned` returns Ready=True after cert-manager-config Application syncs