### PR TITLE
feat(cluster-secret-store): Vault provider for app-secret-store (v0.39.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,50 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.39.3] — 2026-04-30
+
+### Added — Vault provider in `cluster-secret-store` (opt-in `app-secret-store`)
+
+`components/cluster-secret-store/templates/cluster-secret-store-vault.yaml`:
+new template that renders a Vault-backed `ClusterSecretStore` named
+`app-secret-store` ONLY when `.Values.vault.enabled: true`. Default is
+off — chart stays quiet for deployments that don't run Vault.
+
+When activated (passed by platform-root from `components.vault: true`,
+the same toggle that activates the Vault Application), the chart
+renders an additional ClusterSecretStore alongside the existing
+`platform-secret-store` (AWS SM / Azure KV). Two stores let apps pick
+where their secrets live:
+
+- `platform-secret-store` (provider=aws|azure) → platform infra
+  secrets bootstrapped by Terraform (grafana-db, argocd-redis,
+  openai-api-key, etc).
+- `app-secret-store` (provider=vault) → workload application secrets
+  curated by the platform team out-of-band.
+
+Driven by cortex prd 2026-04-30 postmortem: 19 ExternalSecrets in
+`app-*` namespaces were stuck on `SecretSyncedError` because the
+cortex `common-app` Helm chart hardcodes
+`externalSecrets.storeName: app-secret-store` as canonical, but the
+chart had branches only for AWS / Azure — no Vault counterpart. The
+`common-app` Chart.yaml description even says "Platform layer
+provisions the ClusterSecretStore pointing to the chosen backend",
+but that promise was unfulfilled until this release.
+
+Defaults assume in-cluster Vault deployed via the HashiCorp chart at
+`vault.vault.svc.cluster.local:8200`, KV-v2 at `secret/`, kubernetes
+auth method with role `external-secrets` (which `vault-bootstrap.sh`
+provisions). Override any of these in downstream values when running
+a remote / external Vault.
+
+### Files
+
+- `components/cluster-secret-store/templates/cluster-secret-store-vault.yaml` (NEW)
+- `components/cluster-secret-store/values.yaml` (added `vault:` block, default `enabled: false`)
+- `workload-bootstrap/Chart.yaml` (`version` + `appVersion` → 0.39.3)
+- `workload-bootstrap/values.yaml` (`repoVersion` → v0.39.3)
+- `CHANGELOG.md` (this entry)
+
 ## [0.39.2] — 2026-04-30
 
 ### Added — Universal `selfsigned` ClusterIssuer in `cert-manager-config`

--- a/components/cluster-secret-store/templates/cluster-secret-store-vault.yaml
+++ b/components/cluster-secret-store/templates/cluster-secret-store-vault.yaml
@@ -1,0 +1,49 @@
+{{- /*
+  ClusterSecretStore renderer (Vault branch).
+
+  Renders ONLY when `.Values.vault.enabled` is true. Default off — most
+  deployments don't run Vault and the chart should stay quiet for them.
+  When the deployment activates Vault (`components.vault: true` in the
+  platform-root override on the client side), platform-root passes
+  `vault.enabled=true` to this chart and the store appears in the
+  cluster on the next reconcile.
+
+  The store is named `app-secret-store` because that's the canonical
+  storeName the cortex `common-app` Helm chart (and any consumer that
+  follows the same convention) expects:
+
+    externalSecrets:
+      storeName: app-secret-store
+
+  Apps reference this store from any namespace via ClusterSecretStore;
+  the auth path uses the Vault `kubernetes` auth method, where every
+  caller's K8s SA token is exchanged for a Vault token bound to the
+  configured role.
+
+  Defaults assume Vault deployed in the same cluster at the standard
+  service URL produced by the HashiCorp chart (vault.vault.svc.cluster.local).
+  Override `.Values.vault.server` for a remote / external Vault.
+
+  Aligned with cortex prd 2026-04-30 postmortem — apps were waiting
+  for `app-secret-store` because the chart had branches for AWS and
+  Azure but no Vault counterpart.
+*/ -}}
+{{- if .Values.vault.enabled -}}
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: {{ .Values.vault.storeName | default "app-secret-store" | quote }}
+spec:
+  provider:
+    vault:
+      server: {{ .Values.vault.server | quote }}
+      path: {{ .Values.vault.path | quote }}
+      version: {{ .Values.vault.version | quote }}
+      auth:
+        kubernetes:
+          mountPath: {{ .Values.vault.auth.kubernetes.mountPath | quote }}
+          role: {{ .Values.vault.auth.kubernetes.role | quote }}
+          serviceAccountRef:
+            name: {{ .Values.vault.auth.kubernetes.serviceAccount.name | quote }}
+            namespace: {{ .Values.vault.auth.kubernetes.serviceAccount.namespace | quote }}
+{{- end }}

--- a/components/cluster-secret-store/values.yaml
+++ b/components/cluster-secret-store/values.yaml
@@ -64,3 +64,56 @@ aws:
 #   - name: platform-secret-store
 #     region: us-east-1
 stores: []
+
+# ---------------------- Vault provider --------------------------------
+#
+# OPT-IN. When `vault.enabled: true`, the chart renders a Vault-backed
+# `app-secret-store` ClusterSecretStore IN ADDITION to the AWS or Azure
+# `platform-secret-store` rendered by the provider templates above.
+#
+# Default off — most deployments don't run Vault. Activated by passing
+# `vault.enabled=true` from platform-root, which it does only when
+# `components.vault: true` in the platform-root values (the same
+# toggle that activates the Vault Application itself, so this store
+# is always in sync with whether Vault is actually deployed).
+#
+# Why a separate store (not just provider=vault)?
+#   - `platform-secret-store` (AWS SM / Azure KV) holds platform secrets
+#     bootstrapped by Terraform (grafana-db, argocd-redis, opencost,
+#     openai-api-key, etc).
+#   - `app-secret-store` (Vault) holds workload application secrets
+#     curated by the platform team out-of-band.
+#   - Two stores let apps choose where their secrets live without
+#     mixing scopes. The cortex `common-app` chart hardcodes
+#     `storeName: app-secret-store` as the canonical name.
+#
+# Defaults assume Vault is deployed in-cluster at the standard service
+# URL produced by the HashiCorp Vault chart, with kubernetes auth
+# enabled and a role named `external-secrets` that has the `eso` policy
+# (vault-bootstrap.sh provisions both).
+
+vault:
+  enabled: false
+
+  # ClusterSecretStore name. The cortex common-app chart expects
+  # `app-secret-store`. Change only if your fleet uses a different
+  # canonical name.
+  storeName: "app-secret-store"
+
+  # Vault address. Default works for in-cluster Vault deployed via
+  # the HashiCorp chart in the `vault` namespace.
+  server: "http://vault.vault.svc.cluster.local:8200"
+
+  # KV mount path + version. The vault-bootstrap.sh script enables
+  # KV-v2 at `secret/`.
+  path: "secret"
+  version: "v2"
+
+  # Auth via Vault's kubernetes auth method.
+  auth:
+    kubernetes:
+      mountPath: "kubernetes"
+      role: "external-secrets"
+      serviceAccount:
+        name: "external-secrets"
+        namespace: "external-secrets"

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.39.2
-appVersion: "0.39.2"
+version: 0.39.3
+appVersion: "0.39.3"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.39.2
+repoVersion: v0.39.3
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
Adds opt-in Vault ClusterSecretStore (app-secret-store) when components.vault is enabled. Closes the gap surfaced on cortex prd 2026-04-30. Default off — chart stays quiet for non-Vault deployments.