### PR TITLE
fix(network-policies): add metrics ports to cert-manager, cnpg, trivy

### DIFF
--- a/components/network-policies/templates/policies.yaml
+++ b/components/network-policies/templates/policies.yaml
@@ -95,6 +95,14 @@ spec:
     - ports:
         - protocol: TCP
           port: 10250
+    # Prometheus metrics scrape from grafana namespace (alloy)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: grafana
+      ports:
+        - protocol: TCP
+          port: 9402
   egress:
 {{ include "network-policies.dns-egress" . }}
     # All egress (Let's Encrypt ACME, Azure DNS API)
@@ -183,7 +191,11 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: cnpg-system
-    # PostgreSQL clients from grafana namespace
+    # PostgreSQL clients + Prometheus metrics scrape from grafana namespace.
+    # Ports:
+    #   5432 — postgres clients (grafana stores session/dashboard state in CNPG)
+    #   8080 — cnpg-operator metrics (controller_runtime_*, cnpg_*)
+    #   9187 — cnpg postgres exporter sidecar metrics (per-instance pods)
     - from:
         - namespaceSelector:
             matchLabels:
@@ -191,6 +203,10 @@ spec:
       ports:
         - protocol: TCP
           port: 5432
+        - protocol: TCP
+          port: 8080
+        - protocol: TCP
+          port: 9187
   egress:
 {{ include "network-policies.dns-egress" . }}
     # All egress (Azure Blob for WAL backup)
@@ -327,6 +343,18 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: trivy-system
+    # Prometheus metrics scrape from grafana namespace (alloy):
+    #   8080 — trivy-operator (controller-runtime + trivy_*)
+    #   4954 — trivy-server (vulnerability DB ClientServer endpoint)
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: grafana
+      ports:
+        - protocol: TCP
+          port: 8080
+        - protocol: TCP
+          port: 4954
   egress:
 {{ include "network-policies.dns-egress" . }}
     # All egress (container registries, trivy-db download)


### PR DESCRIPTION
## Summary

3 NetworkPolicies blocked the alloy → Mimir scrape paths on AWS. NPs allowed only operational ports (cnpg 5432, vault 8200) but not the metrics ports alloy scrape jobs target. Discovered 2026-04-30 during comprehensive NP audit on cortex prd.

## Cluster evidence (curl from grafana ns)

| target | port | result |
|---|---:|---|
| `cert-manager:9402` | metrics | 000 (timeout) |
| `cnpg-operator:8080` | operator metrics | 000 (timeout) |
| `cnpg-postgres-1:9187` | postgres exporter | 000 (timeout) |
| `trivy-operator:8080` | operator metrics | 000 (timeout) |
| `trivy-server:4954` | server metrics | (would be timeout) |

After fix: all should return 200.

## Mimir state pre-fix

```
up{job="cert-manager"}   → 0 (DOWN)
up{job="cnpg-cluster"}   → 0 (3 instances DOWN)
up{job="cnpg-operator"}  → not in Mimir at all
up{job="trivy-operator"} → 0 (DOWN)
```

## Changes

| NP | added |
|---|---|
| `allow-cert-manager` | `from grafana → 9402` |
| `allow-cnpg-system` | `from grafana` ports 8080, 9187 (was 5432 only) |
| `allow-trivy-system` | new `from grafana → 8080, 4954` rule (was no grafana rule at all) |

Other ports were already covered (vault 8200, KSM 8080, kyverno 8000, argocd 8082-9001, node-exporter 9100, velero 8085).

## Validated via helm template

```
=== allow-cert-manager ===
  from (any): TCP/10250
  from grafana: TCP/9402

=== allow-cnpg-system ===
  from (any): TCP/9443
  from cnpg-system: ALL
  from grafana: TCP/5432, TCP/8080, TCP/9187

=== allow-trivy-system ===
  from trivy-system: ALL
  from grafana: TCP/8080, TCP/4954
```

## Test plan

- [x] `helm template` confirms render emits the expected ingress rules
- [ ] After merge + tag + cortex prd bump: re-run curl test from grafana ns; expect 200 on all 5 targets
- [ ] Verify Mimir `up{job=~"cert-manager|cnpg-cluster|cnpg-operator|trivy-operator"}` returns 1