### PR TITLE
fix(resource-quotas): bump vault quota for 256Mi per-pod requests

### DIFF
--- a/components/resource-quotas/values.yaml
+++ b/components/resource-quotas/values.yaml
@@ -234,13 +234,20 @@ namespaces:
   vault:
     enabled: true
     # Sized for 3-replica Raft HA at chart defaults (50m/128Mi requests,
-    # 250m/256Mi limits per pod). 50% headroom over steady state for
-    # rolling-update surges (4 pods briefly).
-    # PVC count = 3 (one per Raft replica, gp3/Premium_LRS).
+    # 250m/256Mi limits per pod) PLUS rolling-update surge headroom
+    # (4th pod briefly during sts updates) PLUS downstream override room
+    # for clusters that bump per-pod request to ~256Mi (peak observed
+    # ~190Mi on cortex prd 2026-04-30).
+    #
+    # 3-pod baseline: 3 × 256Mi req = 768Mi
+    # 4-pod surge:    4 × 256Mi req = 1024Mi → 1Gi quota
+    # Headroom:        +200Mi for tracker
+    #
+    # PVC count = 3 (one per Raft replica, gp3/Premium_LRS) + 2 surge.
     hard:
-      requests.cpu: "300m"
-      requests.memory: 600Mi
-      limits.cpu: "1500m"
-      limits.memory: 1500Mi
+      requests.cpu: "1"
+      requests.memory: 1200Mi
+      limits.cpu: "2"
+      limits.memory: 2400Mi
       pods: "10"
       persistentvolumeclaims: "5"


### PR DESCRIPTION
Vault sts rolling-update blocked because ResourceQuota was sized for 128Mi/pod (chart default). Block 3 right-sizing bumped to 256Mi/pod, 3-pod total 768Mi > 600Mi quota. Bumps to 1200Mi to fit 4-pod surge with 200Mi tracker headroom.