### PR TITLE
fix(workload-alloy): correct metric_pods relabel (follow-up #206)

### DIFF
--- a/values/workload/alloy.yaml
+++ b/values/workload/alloy.yaml
@@ -249,11 +249,24 @@ alloy:
           action        = "keep"
         }
 
+        // Build __address__ as <pod_ip>:<annotation_port>. The previous
+        // form ("${1}:$0" with only the port annotation as source label)
+        // resolved to "<port>:<port>" because both backrefs pointed at
+        // the same captured value, leaving the address unreachable.
+        // Same fix shipped for the hub Alloy in upstream PR #148.
         rule {
-          source_labels = ["__meta_kubernetes_pod_annotation_prometheus_io_port"]
+          source_labels = ["__address__", "__meta_kubernetes_pod_annotation_prometheus_io_port"]
+          regex         = "([^:]+)(?::\\d+)?;(\\d+)"
+          replacement   = "$1:$2"
           target_label  = "__address__"
+          action        = "replace"
+        }
+
+        // Honor prometheus.io/path annotation when present.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_prometheus_io_path"]
           regex         = "(.+)"
-          replacement   = "${1}:$0"
+          target_label  = "__metrics_path__"
           action        = "replace"
         }
       }


### PR DESCRIPTION
## Summary

Same `metric_pods` relabel bug shipped fixed in the hub Alloy via Estabilis/estabilis-platform#148 — applies to the workload Alloy values too. Without this fix, any pod with `prometheus.io/scrape=true` annotation on a workload cluster has its `/metrics` endpoint silently unreachable (the rule wrote `__address__="<port>:<port>"` instead of `"<pod_ip>:<port>"`).

## Diff

Replaces the broken rule with the canonical Prometheus pattern (combine `__address__` with the annotation port), and adds a companion rule honoring `prometheus.io/path` when present.

## Scope vs hub fix

- **Bug 1 (relabel):** present in workload Alloy → **fixed here**.
- **Bug 2 (OTLP receiver routes):** workload Alloy doesn't run an OTLP receiver; only the hub does. Not applicable.

## Test plan

- [x] `helm template grafana/alloy --version 1.6.2 -f values/workload/alloy.yaml` renders cleanly.
- [x] `alloy fmt` on rendered config: exit 0.
- [x] `alloy run` on rendered config: exit 0; only the expected `sys.env()` errors when run offline.
- [ ] After deploy on a workload cluster (none in production yet): pod with annotation has metrics scraped.

## Urgency

Lower than the hub fix — no workload clusters in production at the time of writing. Merging keeps the workload Alloy ready for the first cluster that gets provisioned.

Closes Estabilis/estabilis-platform-tools#210