### PR TITLE
feat(snapshot-controller): VolumeSnapshotClass component for AWS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.39.10] — 2026-05-06
+
+### Added — `components/snapshot-controller/` chart with VolumeSnapshotClass
+
+New optional component that ships VolumeSnapshotClass resources for the
+in-cluster CSI snapshot-controller. The controller and CRDs themselves
+are installed via cloud-managed mechanisms (AWS: EKS managed addon
+`snapshot-controller`, provisioned in
+`estabilis-platform/providers/aws/eks.tf`).
+
+`values-aws.yaml` ships one VolumeSnapshotClass `ebs-csi-aws` with the
+`velero.io/csi-volumesnapshot-class: "true"` discovery label so Velero
+backups can snapshot EBS PVs (previously fell back to no snapshot →
+`PartiallyFailed` backups, observed on cortex prd 2026-05-05). Default
+class annotation set so workloads requesting `kind: VolumeSnapshot`
+without `snapshotClassName` resolve to this VSC.
+
+Consumed by `bootstrap/platform-root/templates/snapshot-controller.yaml`
+in estabilis-platform v0.46.0+ (AWS-only, sync wave 6 — before
+velero in wave 7).
+
 ## [0.39.9] — 2026-05-04
 
 ### Fixed — Workload Alloy `metric_pods` relabel for annotation scrape

--- a/components/snapshot-controller/Chart.yaml
+++ b/components/snapshot-controller/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: snapshot-controller
+description: VolumeSnapshotClasses for the in-cluster CSI snapshot-controller
+type: application
+version: 0.1.0

--- a/components/snapshot-controller/templates/volumesnapshotclasses.yaml
+++ b/components/snapshot-controller/templates/volumesnapshotclasses.yaml
@@ -1,0 +1,21 @@
+{{- range .Values.volumeSnapshotClasses }}
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: {{ .name }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+driver: {{ .driver }}
+deletionPolicy: {{ .deletionPolicy }}
+{{- with .parameters }}
+parameters:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/components/snapshot-controller/values-aws.yaml
+++ b/components/snapshot-controller/values-aws.yaml
@@ -1,0 +1,21 @@
+# AWS-specific VolumeSnapshotClass for the EBS CSI driver.
+#
+# Why label `velero.io/csi-volumesnapshot-class: "true"`:
+#   Velero discovers which VolumeSnapshotClass to use for a given
+#   StorageClass by matching this label. Without it, Velero falls back
+#   to no snapshot — backup completes with phase=PartiallyFailed and
+#   the source PV is skipped (observed on cortex 2026-05-05 prior to
+#   this component shipping).
+#
+# Why `is-default-class: "true"`:
+#   When a workload requests `kind: VolumeSnapshot` without specifying
+#   a snapshotClassName, k8s picks the default. Single VSC per cluster
+#   today — safe to flag as default.
+volumeSnapshotClasses:
+  - name: ebs-csi-aws
+    annotations:
+      snapshot.storage.kubernetes.io/is-default-class: "true"
+    labels:
+      velero.io/csi-volumesnapshot-class: "true"
+    driver: ebs.csi.aws.com
+    deletionPolicy: Delete

--- a/components/snapshot-controller/values.yaml
+++ b/components/snapshot-controller/values.yaml
@@ -1,0 +1,15 @@
+# VolumeSnapshotClass declarations for the CSI snapshot-controller.
+#
+# The snapshot-controller and its CRDs (volumesnapshots.snapshot.storage.k8s.io
+# et al.) are installed by the cloud-managed mechanism for each provider:
+#   • AWS  — EKS managed addon `snapshot-controller` (provisioned in
+#            estabilis-platform/providers/aws/eks.tf)
+#   • Azure — TBD (deferred until a workload demands CSI snapshots)
+#
+# This component only ships the VolumeSnapshotClass(es) consumed by Velero
+# and other workloads. AWS values live in `values-aws.yaml` (loaded by the
+# Application via `valueFiles` against `global.provider`).
+#
+# Default: empty list — no VolumeSnapshotClass rendered when no provider
+# overlay applies.
+volumeSnapshotClasses: []

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.39.9
-appVersion: "0.39.9"
+version: 0.39.10
+appVersion: "0.39.10"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.39.9
+repoVersion: v0.39.10
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
## Summary

- New `components/snapshot-controller/` chart that ships a single VolumeSnapshotClass `ebs-csi-aws` with the `velero.io/csi-volumesnapshot-class: "true"` discovery label.
- Bumps `workload-bootstrap` Chart.yaml + values.yaml + repoVersion to `v0.39.10`.

## Why

Velero CSI backups silently skip PV snapshotting when no VolumeSnapshotClass carries the velero discovery label. Observed on cortex prd 2026-05-05: 14 PVs in PartiallyFailed phase after the KMS fix (v0.45.1) unmasked this pre-existing gap.

The snapshot-controller deployment + CRDs come from the EKS managed addon, provisioned in **estabilis-platform v0.46.0** (paired PR). This component only ships the VSC.

## Pairing

- estabilis-platform v0.46.0 — adds `snapshot-controller` to `local.default_addons` + `bootstrap/platform-root/templates/snapshot-controller.yaml` (AWS-only, sync wave 6, consumes this component's values).

## Test plan

- [x] `helm template` renders 1 doc with the AWS overlay; 0 docs without
- [x] YAML parses cleanly via `yaml.safe_load_all`
- [ ] After merge → cortex bump → terraform apply: `kubectl get volumesnapshotclass ebs-csi-aws` returns the resource with the velero label
- [ ] Velero ad-hoc backup post-deploy → phase=Completed (no PartiallyFailed) and PV count > 0 in items