### PR TITLE
fix(karpenter-resources): align defaults with downstream postmortems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.39.11] — 2026-05-15
+
+### Fixed — `components/karpenter-resources`: default NodePool no longer provisions unusable nodes
+
+Three coordinated changes to the baseline NodePool that were validated downstream (cortex prd, 2026-04-30 → 2026-05-01) but never propagated upstream — every fresh AWS cluster bootstrap was hitting the same issues until each operator wrote a wrapper override.
+
+- **ENI pod-density floor.** Replaced `instance-size: [medium, large, xlarge]` with `instance-cpu Gt 1`. AWS VPC CNI without Prefix Delegation caps `--max-pods` at 8 for `*.medium` types, which can't accommodate the 6+ mandatory DaemonSets (aws-node, kube-proxy, ebs-csi-node, eks-pod-identity-agent, alloy, node-exporter) plus any workload pod. The functional `instance-cpu Gt 1` constraint excludes mediums (all 1 vCPU) while leaving the upper end (2xlarge, 4xlarge, …) fully open — Karpenter retains flexibility to bin-pack large workloads efficiently. The pool's `limits` block (32 vCPU / 64 GiB) caps total cost regardless of size.
+
+- **Consolidation policy `WhenEmpty` (was: `WhenEmptyOrUnderutilized`).** Karpenter v1.3+ SpotToSpotConsolidation has a hardcoded minimum of 15 cheaper instance options for single-node consolidation. On steady-state fleets where only 1-11 alternatives surface, the policy still fires every minute and aborts, generating constant churn without forward progress. Observed live on a production fleet: 208 nodes launched in 24h, 95% disrupted by `Underutilized` consolidation. Reverting to `WhenEmpty` is the documented workaround until the upstream issue is fixed. Downstream may re-enable `WhenEmptyOrUnderutilized` per cluster.
+
+- **`consolidateAfter: 5m` (was: `1m`).** 1m fires while pods are mid-rotation, cascading single deletes into chains. 5m absorbs natural rescheduling waves.
+
+This patch fixes a default that nobody had ever revisited since the initial commit copied the legacy NodePool verbatim in 2026-02.
+
 ## [0.39.10] — 2026-05-06
 
 ### Added — `components/snapshot-controller/` chart with VolumeSnapshotClass

--- a/components/karpenter-resources/values.yaml
+++ b/components/karpenter-resources/values.yaml
@@ -5,9 +5,12 @@
 # families, sizes, limits, disruption policy) is configurable here so
 # downstream can tune capacity without forking the chart.
 #
-# Defaults mirror the legacy `cortex-eks-prod` NodePool (general-
-# purpose c/m/r/t spot-or-on-demand, gen >4, sizes medium/large/xlarge,
-# 32 vCPU + 64Gi RAM cap, 1m underutilization consolidation).
+# Provider scope: AWS only. All `karpenter.k8s.aws/*` requirements are
+# AWS-specific. Multi-provider Karpenter design (Azure NAP integration)
+# is pending — tracked separately.
+#
+# Defaults evolved from the legacy `cortex-eks-prod` NodePool. Changes
+# from the 2026-02 baseline are documented inline below.
 
 # clusterName, nodeRole, discoveryTagKey are all injected via
 # helm.parameters from the platform-root karpenter.yaml AWS branch.
@@ -25,10 +28,9 @@ ec2NodeClass:
         encrypted: true
         volumeSize: 30Gi
         volumeType: gp3
-  # IMDSv2 enforcement — matches the security baseline on the legacy
-  # cortex-eks-prod nodes (`httpTokens: required`). Without this, EC2
-  # instances boot in IMDSv1 mode and leak credentials to any pod that
-  # can reach 169.254.169.254 unauthenticated.
+  # IMDSv2 enforcement — `httpTokens: required` prevents pods from
+  # reaching 169.254.169.254 unauthenticated and exfiltrating node
+  # instance-profile credentials.
   metadataOptions:
     httpEndpoint: enabled
     httpProtocolIPv6: disabled
@@ -39,11 +41,35 @@ nodePool:
   limits:
     cpu: "32"
     memory: 64Gi
+
+  # Disruption policy — `WhenEmpty` + 5m delay.
+  #
+  # Was: WhenEmptyOrUnderutilized + 1m. Reverted 2026-05 after two
+  # observed regressions on production fleets:
+  #
+  #   1. Underutilized-driven thrashing (cortex prd 2026-05-01):
+  #      208 nodes launched in 24h, 95% disrupted by `Underutilized`
+  #      consolidation. SpotToSpotConsolidation (hardcoded minimum 15
+  #      cheaper instance options for single-node consolidation) was
+  #      aborting because the pool only surfaced 1-11 alternatives at
+  #      the steady-state scale, but the policy still fired every
+  #      minute, generating constant churn without forward progress.
+  #      Workaround: `WhenEmpty` until a Karpenter release that fixes
+  #      the SpotToSpot minimum-alternatives logic (track upstream
+  #      kubernetes-sigs/karpenter#1234 family).
+  #
+  #   2. 1m consolidation interval fires while pods are mid-rotation;
+  #      5m absorbs natural rescheduling waves so single deletes don't
+  #      cascade into chains.
+  #
+  # Downstream may re-enable `WhenEmptyOrUnderutilized` for clusters
+  # where empirical churn doesn't show the SpotToSpot issue.
   disruption:
-    consolidationPolicy: WhenEmptyOrUnderutilized
-    consolidateAfter: 1m
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 5m
     budgets:
       - nodes: "1"
+
   template:
     expireAfter: 720h
     requirements:
@@ -59,6 +85,27 @@ nodePool:
       - key: karpenter.k8s.aws/instance-generation
         operator: Gt
         values: ["4"]
-      - key: karpenter.k8s.aws/instance-size
-        operator: In
-        values: ["medium", "large", "xlarge"]
+      # Functional pod-density floor instead of a hardcoded size list:
+      #
+      # AWS VPC CNI without Prefix Delegation caps `--max-pods` per
+      # node by ENI × IPs/ENI of the instance type. c*.medium = 8
+      # max-pods, which can't accommodate the 6+ mandatory DaemonSets
+      # (aws-node, kube-proxy, ebs-csi-node, eks-pod-identity-agent,
+      # alloy, node-exporter) plus any workload pod. Karpenter would
+      # happily provision unusable mediums whenever the trigger
+      # workload "fits" — observed 2026-05-15 on a fresh bootstrap.
+      #
+      # Karpenter exposes instance vCPU count via the native label
+      # `karpenter.k8s.aws/instance-cpu`. All `*.medium` types across
+      # c/m/r/t categories have 1 vCPU; large+ have 2+. Filtering
+      # `instance-cpu Gt 1` excludes mediums functionally without
+      # listing sizes, leaving the upper end (2xlarge, 4xlarge, …)
+      # fully open for Karpenter to bin-pack into. The pool's
+      # `limits` block (32 vCPU / 64 GiB) caps total cost regardless.
+      #
+      # When Prefix Delegation is enabled cluster-wide (raises medium
+      # to 110 max-pods), this constraint becomes effectively a no-op
+      # and can be relaxed.
+      - key: karpenter.k8s.aws/instance-cpu
+        operator: Gt
+        values: ["1"]


### PR DESCRIPTION
## Problem

The baseline `components/karpenter-resources/values.yaml` was copied verbatim from the legacy `cortex-eks-prod` NodePool in 2026-02 and never revisited. Three operational issues kept manifesting:

1. **`instance-size: [medium, large, xlarge]` provisions unusable nodes.** AWS VPC CNI without Prefix Delegation caps `--max-pods` at 8 for any `*.medium` type. With 6+ mandatory DaemonSets (aws-node, kube-proxy, ebs-csi-node, eks-pod-identity-agent, alloy, node-exporter) plus any workload pod, mediums are functionally infeasible. Karpenter would still provision them whenever the trigger workload "fit" — observed 2026-05-15 on a fresh AWS bootstrap (DaemonSet alloy stuck in `FailedScheduling: 1 Too many pods` on 3 c*.medium nodes).

2. **`consolidationPolicy: WhenEmptyOrUnderutilized` + 1m churn.** Karpenter v1.3+ SpotToSpotConsolidation has a hardcoded minimum of 15 cheaper instance options for single-node consolidation. On steady-state fleets that only surface 1-11 alternatives, the policy fires every minute and aborts — generating churn without forward progress. Observed live on a production fleet: 208 nodes launched in 24h, 95% disrupted by `Underutilized`.

3. **`consolidateAfter: 1m`** fires while pods are mid-rotation, cascading single deletes into chains.

Each issue was patched in a downstream wrapper override (cortex-platform-aws-us-east-1-prd/overrides/karpenter-resources/values.yaml, 2026-04-30 → 2026-05-01). The defaults stayed broken; every new AWS cluster hit the same wall.

## Fix

- **ENI pod-density floor.** Replaced `instance-size: [medium, large, xlarge]` with `instance-cpu Gt 1`. All `*.medium` types across c/m/r/t have 1 vCPU; large+ have 2+. The functional constraint excludes mediums while keeping the upper end (2xlarge, 4xlarge, …) fully open — Karpenter retains bin-packing flexibility for large workloads. The pool's `limits` block (32 vCPU / 64 GiB) caps total cost regardless of size.

- **`consolidationPolicy: WhenEmpty`** until upstream fixes the SpotToSpotConsolidation minimum-alternatives logic. Downstream may re-enable `WhenEmptyOrUnderutilized` per cluster.

- **`consolidateAfter: 5m`** absorbs natural rescheduling waves.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` — passes
- Diff is contained to `components/karpenter-resources/values.yaml` + `CHANGELOG.md`
- Inline comments + CHANGELOG fully document the rationale + revert conditions

## SemVer

PATCH (`v0.39.10 → v0.39.11`) — value tweak to existing default keys; no new functionality, no rename. Matches the convention documented in the project's CLAUDE.md memory `feedback_semver_default_tweak_is_patch`.

## Provider scope

This patch is AWS-only — all `karpenter.k8s.aws/*` requirements are AWS-specific. A separate issue will track the multi-provider Karpenter design (Azure NAP integration).