### PR TITLE
fix(karpenter-resources): add instance-memory Gt 4096 floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.39.12] — 2026-05-15
+
+### Fixed — `components/karpenter-resources`: memory floor (`instance-memory Gt 4096`)
+
+Follow-up to v0.39.11. The ENI pod-density fix unblocked `*.medium` saturation, but the surviving `*.large` nodes still ran into a different ceiling: memory exhaustion as more DaemonSets joined the cluster post-provisioning.
+
+**Root cause.** Karpenter calculates DaemonSet overhead **only at the moment of provisioning** a node. Once the node is up, adding more DaemonSets to the cluster (ESO, alloy, observability stack, …) gradually saturates the node. Karpenter does NOT revisit sizing — the NodePool spec didn't change, the node isn't `Drifted`, and the `WhenEmpty` consolidation policy doesn't replace busy nodes. The result is "node slowly tightens until the next DaemonSet pod stays `Pending` forever".
+
+**Fix.** Add `karpenter.k8s.aws/instance-memory Gt 4096` (MiB) to the default NodePool requirements. Excludes anything with ≤ 4 GiB raw memory (i.e., excludes `*.large`), forcing `xlarge+` as the minimum. With ~6.5 GiB allocatable per node, the DaemonSet set (~950 Mi) plus typical workload pods has comfortable headroom; future DaemonSet additions land without retroactively breaking provisioned nodes.
+
+**Trade-off.** Roughly 2x the hourly cost vs `*.large`. Compensated by (a) one xlarge bin-packs the workload of 1.5-2 larges, (b) eliminates the entire failure mode described above.
+
+**Combined effect of v0.39.11 + v0.39.12**: any node Karpenter provisions has ≥ 2 vCPU AND > 4 GiB raw memory, which means it can host any reasonable DaemonSet count plus workload. The default became operationally sane.
+
 ## [0.39.11] — 2026-05-15
 
 ### Fixed — `components/karpenter-resources`: default NodePool no longer provisions unusable nodes

--- a/components/karpenter-resources/values.yaml
+++ b/components/karpenter-resources/values.yaml
@@ -109,3 +109,43 @@ nodePool:
       - key: karpenter.k8s.aws/instance-cpu
         operator: Gt
         values: ["1"]
+
+      # Memory floor — guarantees DaemonSet headroom regardless of which
+      # instance family Karpenter picks.
+      #
+      # The 2026-05-15 cortex HML postmortem traced the alloy DaemonSet
+      # FailedScheduling not just to ENI pod-density (fixed in v0.39.11
+      # via instance-cpu Gt 1) but also to memory exhaustion on the
+      # surviving `*.large` nodes. Karpenter computes DaemonSet overhead
+      # ONLY at provisioning time — once a node is up, adding more
+      # DaemonSets to the cluster (ESO, alloy, Beyla, …) gradually
+      # saturates the node, but Karpenter never marks it Drifted (the
+      # NodePool spec didn't change) and never reconsiders sizing.
+      #
+      # Observed DS overhead on a steady-state platform cluster:
+      #   - 4 system DaemonSets (aws-node, kube-proxy, ebs-csi-node,
+      #     eks-pod-identity-agent): ~250 Mi
+      #   - 2 observability DaemonSets (node-exporter, alloy): ~400 Mi
+      #   - 1-2 platform DaemonSets (snapshot-controller, hubble, …):
+      #     ~300 Mi
+      #   → DS overhead alone ≈ 950 Mi
+      #
+      # A c*.large has 4 GiB raw memory, ~3.1 GiB allocatable after
+      # kubelet + reservations. That leaves ~2.2 GiB for workload —
+      # not enough headroom once 2-3 typical pods land. Excluding
+      # everything ≤ 4 GiB raw memory forces xlarge+ as the minimum
+      # (8 GiB raw, ~6.5 GiB allocatable), giving the DaemonSet set
+      # comfortable room to grow without retroactively breaking
+      # provisioned nodes.
+      #
+      # Trade-off: ~2x hourly cost vs `large`. Compensated by:
+      #   (a) one xlarge bin-packs the workload of 1.5-2 larges,
+      #   (b) eliminates an entire class of "node slowly tightens
+      #       until DS pod stays Pending forever" failures.
+      #
+      # The value 4096 is in MiB and is exclusive ('Gt'). Instance
+      # types with `memory >= 8192 MiB raw` satisfy the constraint;
+      # the 4 GiB raw types (large) are excluded.
+      - key: karpenter.k8s.aws/instance-memory
+        operator: Gt
+        values: ["4096"]


### PR DESCRIPTION
## Problem

Follow-up to #42. The ENI pod-density fix in v0.39.11 (`instance-cpu Gt 1`) unblocked `*.medium` saturation, but a second class of failure surfaced on surviving `*.large` nodes: **memory exhaustion as DaemonSets accumulate post-provisioning**.

### Root cause

Karpenter calculates DaemonSet overhead **only at the moment of provisioning** a node. Once the node is up, adding more DaemonSets to the cluster gradually saturates it:

```
1. Pod Pending → Karpenter picks c6a.large (fits current DS set + trigger pod)
2. Node up, all pods running ✓
3. Cluster adds ESO DaemonSet → fits
4. Cluster adds alloy DaemonSet → fits
5. Cluster adds Beyla → starts to tighten
6. Workload grows → memory pressure (99% on observed `ip-10-207-3-220`)
7. Next DS pod can't fit → stays Pending forever
```

Karpenter never revisits sizing because:
- **NodePool spec didn't change** → no Drift detection
- **Node isn't empty** → `WhenEmpty` consolidation skips
- **No "continuous capacity re-evaluation"** primitive exists in Karpenter

Observed on cortex HML 2026-05-15: `grafana-alloy-8kxfz` DaemonSet pod stuck `FailedScheduling` on a `c6a.large` with 99% memory utilization (3112 Mi used / 3193 Mi allocatable, 81 Mi free vs 306 Mi needed).

## Fix

Add `karpenter.k8s.aws/instance-memory Gt 4096` (MiB) to the default NodePool requirements. Excludes anything with ≤ 4 GiB raw memory (i.e., `*.large` and below), forcing `xlarge+` (8 GiB raw, ~6.5 GiB allocatable) as the minimum.

DaemonSet overhead observed on a steady-state platform cluster:
- 4 system DS (aws-node, kube-proxy, ebs-csi-node, eks-pod-identity-agent): ~250 Mi
- 2 observability DS (node-exporter, alloy): ~400 Mi
- 1-2 platform DS (snapshot-controller, hubble, …): ~300 Mi
- **Total: ~950 Mi**

With ~6.5 GiB allocatable per node:
- DS overhead (~950 Mi) ≈ 15%
- Workload room ≈ 5.5 GiB
- Comfortable headroom for DaemonSet additions without retroactively breaking provisioned nodes

## Trade-off

~2x hourly cost vs `*.large`. Compensated by:

- **Better bin-packing**: one xlarge bin-packs the workload of ~1.5-2 larges
- **Eliminates entire failure mode**: "node slowly tightens until next DS pod stays Pending"
- **Operational sanity**: capacity is always > minimum reasonable headroom

## Combined effect of v0.39.11 + v0.39.12

Any node Karpenter provisions has `>= 2 vCPU AND > 4 GiB raw memory`. The default became operationally sane for a platform cluster — no override needed downstream just to avoid stuck DaemonSets.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` — passes
- Diff contained to `components/karpenter-resources/values.yaml` (constraint addition) + `CHANGELOG.md`
- Inline comments document rationale + revert conditions

## SemVer

PATCH (`v0.39.11 → v0.39.12`) — adds a constraint to an existing default; no new functionality, no API change. Memory `feedback_semver_default_tweak_is_patch` applies.

## Follow-up

After merge + release, `estabilis-platform` bumps default `platformGitopsVersion v0.39.11 → v0.39.12` (separate PATCH release `v0.53.7`). Clusters consuming the new release see Karpenter mark all `*.large` nodes as Drifted and replace them with `xlarge+`.