### PR TITLE
fix(resource-quotas): bump argocd limits.memory 16Gi -> 32Gi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.39.13] — 2026-05-17
+
+### Fixed — `components/resource-quotas`: argocd namespace `limits.memory` 16Gi → 32Gi
+
+The default ResourceQuota for the `argocd` namespace was sized for a single-replica control plane (~13Gi steady-state). Operators following the legacy `cortex-eks-prod` HA baseline set `controller.replicas: 2` in their downstream `overrides/argocd/values.yaml`. With a second `application-controller` pod requesting 5Gi memory, total exceeds 16Gi and the StatefulSet retries `FailedCreate` indefinitely.
+
+The downstream symptom is silent and severe: ArgoCD enables sharding when `ARGOCD_CONTROLLER_REPLICAS=2`, the cluster is hash-assigned to shard 1, and with no `application-controller-1` pod (blocked by quota), nobody reconciles that shard. Applications freeze at their last successful sync state — observed 18h of `platform-root` `OutOfSync` on cortex HML with no error surfaced anywhere obvious; only `kubectl describe statefulset` showed the `exceeded quota` warnings, 103 retries deep.
+
+Bumping `limits.memory` to 32Gi accommodates the HA configuration with headroom for bulk sync waves. Memory cap is cheap relative to the failure mode.
+
 ## [0.39.12] — 2026-05-15
 
 ### Fixed — `components/karpenter-resources`: memory floor (`instance-memory Gt 4096`)

--- a/components/resource-quotas/values.yaml
+++ b/components/resource-quotas/values.yaml
@@ -80,7 +80,27 @@ namespaces:
       requests.cpu: "4"
       requests.memory: 8Gi
       limits.cpu: "16"
-      limits.memory: 16Gi
+      # Was 16Gi until 2026-05-17. Bumped to 32Gi after the cortex HML
+      # postmortem: the namespace hosts a single ArgoCD installation
+      # whose application-controller alone reserves 5Gi (lives-state
+      # cache for ~40 managed Applications), repo-server x2 reserves
+      # 4Gi, argocd-server x2 reserves 2Gi, plus the
+      # applicationset-controller / notifications / dex / redis tail.
+      # Steady-state usage already sits at ~13Gi with controller.replicas=1.
+      # When operators set controller.replicas=2 for HA (matching the
+      # legacy cortex-eks-prod baseline), the second controller pod
+      # cannot be admitted under a 16Gi cap and StatefulSet retries
+      # FailedCreate every ~10min. Sharding then assigns clusters to
+      # a shard whose pod never exists — reconcile silently stops and
+      # Applications stay frozen at the last successful sync (observed
+      # 18h of OutOfSync on platform-root, recovery required force-
+      # deleting controller-0 + manual sync).
+      #
+      # 32Gi accommodates: 2x application-controller (10Gi) + 2x
+      # repo-server (4Gi) + 2x argocd-server (2Gi) + tail (~3Gi) = ~19Gi
+      # peak; rest is headroom for spike consumption during bulk sync
+      # waves. Memory cap is cheap relative to the failure mode.
+      limits.memory: 32Gi
       pods: "30"
       persistentvolumeclaims: "5"
     # ArgoCD's application-controller alone needs ~1Gi to manage ~40 Apps;


### PR DESCRIPTION
## Problem

The default `ResourceQuota` for the `argocd` namespace caps `limits.memory` at 16Gi. The chart `core/components/argocd/values.yaml` defaults `controller.replicas: 1` (steady-state ~13Gi usage), so the cap is fine for the upstream default. **But operators following the legacy HA baseline set `controller.replicas: 2` in their downstream `overrides/argocd/values.yaml`** — and that doesn't fit.

Each `application-controller` pod requests 5Gi memory (live-state cache for ~40 managed Applications). With two of them plus the rest of the stack:

| Component | Replicas | Memory limit | Total |
|---|---|---|---|
| application-controller | 2 | 5Gi | 10Gi |
| repo-server | 2 | 2Gi | 4Gi |
| argocd-server | 2 | 1Gi | 2Gi |
| applicationset-controller | 2 | 512Mi | 1Gi |
| redis, notifications, dex, ... | 1 each | ~250-512Mi | ~1.5Gi |
| **Total** | | | **~18.5Gi** |

Exceeds the 16Gi cap, so the StatefulSet retries `FailedCreate` indefinitely.

## Why this fails silently

ArgoCD enables sharding when `ARGOCD_CONTROLLER_REPLICAS=2`. The cluster gets hash-assigned to a shard (e.g. shard 1). With `application-controller-0` (shard 0) running and `application-controller-1` (shard 1) blocked by quota, **no pod is responsible for reconciling the assigned shard**. Reconcile silently stops. Applications freeze at their last successful sync state — no error surfaced in `kubectl get application`, no event on the Application object, nothing in `argocd-server` logs. The only trace is `kubectl describe statefulset argocd-application-controller` showing `FailedCreate ... exceeded quota` warnings stacking up.

Observed on cortex HML 2026-05-17: 18h of `platform-root` `OutOfSync` with no actionable error anywhere obvious. Recovery required force-deleting `application-controller-0` (which let the existing pod settle on the now-available shard) plus a manual sync trigger.

## Fix

Bump `argocd.hard.limits.memory` from `16Gi` to `32Gi` in `components/resource-quotas/values.yaml`. Accommodates the HA configuration (`controller.replicas: 2`) with headroom for bulk sync waves and any future growth in the ArgoCD installation. Memory cap is cheap relative to the silent failure mode it prevents.

## SemVer

PATCH (`v0.39.12 → v0.39.13`) — value tweak to an existing default. No API or behavior change for downstreams that don't override quota or controller replicas.

## Follow-up

`estabilis-platform` will be bumped to consume this release (`platformGitopsVersion v0.39.12 → v0.39.13`), separate PATCH.