### PR TITLE
fix(workload-bootstrap): ADR 0029 compliance — auto-prune on Safe-class templates (v0.39.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.39.14] — 2026-05-18
+
+### Fixed — `workload-bootstrap`: ADR 0029 compliance — auto-prune on Safe-class templates
+
+Six Application/ApplicationSet templates in `workload-bootstrap/templates/` were out of compliance with [ADR 0029 — Auto-prune policy](https://github.com/Estabilis/estabilis-platform-tools/blob/main/docs/adr/0029-auto-prune-policy.md). The ADR classifies each template by risk (Safe / Coupled / CRD-owning / Foundational) and dictates whether `automated.prune: true` is appropriate.
+
+The six templates emit only CR instances or Kubernetes-native resources (no CRDs, no operators, no cross-chart `optional: false` coupling) — they qualify as **Safe class** and should auto-prune so that gate flips and chart cleanups don't leak orphan resources cluster-wide.
+
+| Template | Before | After |
+|---|---|---|
+| `hubble-ui.yaml` | `automated.selfHeal: true` only | `automated.{prune,selfHeal}: true` |
+| `kube-state-metrics.yaml` | `automated.selfHeal: true` only | `automated.{prune,selfHeal}: true` |
+| `kyverno-exceptions.yaml` | no `automated` block | `automated.{prune,selfHeal}: true` |
+| `kyverno-policies.yaml` | no `automated` block | `automated.{prune,selfHeal}: true` |
+| `network-policies.yaml` | no `automated` block | `automated.{prune,selfHeal}: true` |
+| `resource-quotas.yaml` | no `automated` block | `automated.{prune,selfHeal}: true` |
+
+The `kyverno-policies` template comment ("no automated sync — destructive changes to ClusterPolicies must be operator-initiated") predated ADR 0029 and contradicted the ADR's explicit classification of `kyverno-policies` as **Safe / Enabled** (ADR 0029 §"Platform components", line 93). Comment updated to reflect the ADR decision.
+
+Same change applied to the `kyverno-exceptions` template comment ("no automated sync") — the template now syncs automatically with prune, consistent with the matching `client-kyverno-exceptions` template that was already on `automated.{prune,selfHeal}: true`.
+
+**Behavioral impact downstream.** Workload clusters consuming this chart will reconcile `hubble-ui`, `kube-state-metrics`, `kyverno-exceptions`, `kyverno-policies`, `network-policies`, `resource-quotas` automatically on git pushes to the workload-bootstrap source. Orphans from removed templates or flipped gates are pruned automatically. `selfHeal: true` reverts out-of-band `kubectl patch` operations — operators with active incident debugging should be aware.
+
 ## [0.39.13] — 2026-05-17
 
 ### Fixed — `components/resource-quotas`: argocd namespace `limits.memory` 16Gi → 32Gi

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.39.13
-appVersion: "0.39.13"
+version: 0.39.14
+appVersion: "0.39.14"

--- a/workload-bootstrap/templates/hubble-ui.yaml
+++ b/workload-bootstrap/templates/hubble-ui.yaml
@@ -58,6 +58,7 @@ spec:
         namespace: "kube-system"
       syncPolicy:
         automated:
+          prune: true
           selfHeal: true
         retry:
           limit: 10

--- a/workload-bootstrap/templates/kube-state-metrics.yaml
+++ b/workload-bootstrap/templates/kube-state-metrics.yaml
@@ -72,6 +72,7 @@ spec:
       syncPolicy:
         {{- include "workload-bootstrap.managedNamespaceMetadata" . | nindent 8 }}
         automated:
+          prune: true
           selfHeal: true
         retry:
           limit: 10

--- a/workload-bootstrap/templates/kyverno-exceptions.yaml
+++ b/workload-bootstrap/templates/kyverno-exceptions.yaml
@@ -15,7 +15,9 @@
     - Emit PolicyException CRDs for per-resource, per-policy escapes.
 
   Mirrors hub kyverno-exceptions Application exactly (sync-wave 4 —
-  after policies, no automated sync).
+  after policies). Auto-sync with prune per ADR 0029 (Safe class —
+  PolicyException CRs only; pruning a removed exception = no escape
+  hatch for that resource; reversible by re-adding to the chart).
 */ -}}
 {{- if index .Values.components "kyverno-exceptions" }}
 ---
@@ -65,6 +67,9 @@ spec:
         server: "{{ `{{server}}` }}"
         namespace: "kyverno"
       syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
         retry:
           limit: 10
           backoff:

--- a/workload-bootstrap/templates/kyverno-policies.yaml
+++ b/workload-bootstrap/templates/kyverno-policies.yaml
@@ -19,9 +19,9 @@
        workload overlay from values/workload/kyverno-policies.yaml.
 
   No managedNamespaceMetadata: the kyverno namespace is already created
-  by the workload-kyverno ApplicationSet. Mirrors hub kyverno-policies
-  Application exactly (no automated sync — destructive changes to
-  ClusterPolicies must be operator-initiated).
+  by the workload-kyverno ApplicationSet. Auto-sync with prune per
+  ADR 0029 (Safe class — ClusterPolicy CRs only; pruning a removed
+  policy = no enforcement; reversible by re-adding to the chart).
 */ -}}
 {{- if index .Values.components "kyverno-policies" }}
 ---
@@ -85,6 +85,9 @@ spec:
         # ADR 0005 L1 provenance annotations (built-at, build-id, etc.)
         # are handled globally via argocd-cm resource.customizations.ignoreDifferences.all
       syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
         retry:
           limit: 10
           backoff:

--- a/workload-bootstrap/templates/network-policies.yaml
+++ b/workload-bootstrap/templates/network-policies.yaml
@@ -92,6 +92,9 @@ spec:
         server: "{{ `{{server}}` }}"
         namespace: "default"
       syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
         retry:
           limit: 10
           backoff:

--- a/workload-bootstrap/templates/resource-quotas.yaml
+++ b/workload-bootstrap/templates/resource-quotas.yaml
@@ -84,6 +84,9 @@ spec:
         server: "{{ `{{server}}` }}"
         namespace: "default"
       syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
         retry:
           limit: 10
           backoff:

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.39.13
+repoVersion: v0.39.14
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
## Summary

Six Application/ApplicationSet templates in `workload-bootstrap/templates/` were out of compliance with [ADR 0029 — Auto-prune policy](https://github.com/Estabilis/estabilis-platform-tools/blob/main/docs/adr/0029-auto-prune-policy.md). All six emit only CR instances or Kubernetes-native resources (no CRDs, no operators, no cross-chart `optional: false` coupling) — **Safe class** per ADR 0029.

## Fixes

| Template | Before | After |
|---|---|---|
| `hubble-ui.yaml` | `automated.selfHeal: true` only | `automated.{prune,selfHeal}: true` |
| `kube-state-metrics.yaml` | `automated.selfHeal: true` only | `automated.{prune,selfHeal}: true` |
| `kyverno-exceptions.yaml` | no `automated` block | `automated.{prune,selfHeal}: true` |
| `kyverno-policies.yaml` | no `automated` block | `automated.{prune,selfHeal}: true` |
| `network-policies.yaml` | no `automated` block | `automated.{prune,selfHeal}: true` |
| `resource-quotas.yaml` | no `automated` block | `automated.{prune,selfHeal}: true` |

## Comment updates

- `kyverno-policies.yaml` comment ("no automated sync — destructive changes to ClusterPolicies must be operator-initiated") predated ADR 0029 and contradicted the ADR's explicit classification of `kyverno-policies` as **Safe / Enabled** (ADR 0029, line 93). Comment updated.
- Same applied to `kyverno-exceptions.yaml` comment ("no automated sync").

## Behavioral impact downstream

Workload clusters consuming this chart will reconcile the six components automatically on git pushes to the workload-bootstrap source. Orphans from removed templates or flipped gates are pruned. `selfHeal: true` reverts out-of-band `kubectl patch` operations — operators with active incident debugging should be aware.

## Test plan

- [x] `helm template workload-bootstrap workload-bootstrap/` renders without error
- [x] All 6 fixed templates emit `automated.{prune,selfHeal}: true`
- [x] Existing templates that should NOT have prune (alloy, cert-manager, external-dns, external-secrets, kyverno, node-exporter, traefik) still emit only `selfHeal: true`
- [ ] HML validation after release (cortex AWS HML)

## Release

- Chart.yaml: `0.39.13` → `0.39.14`
- values.yaml: `repoVersion: v0.39.14`
- CHANGELOG.md entry added