### PR TITLE
feat(karpenter): enable NodeRepair feature gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+### Added — `values/platform/karpenter`: enable `NodeRepair` feature gate
+
+Karpenter v1.x ships `NodeRepair` as a beta feature gate, default-off. With it disabled, Karpenter only acts on node lifecycle events delivered through the SQS interruption queue (spot reclaim, AZ rebalance, scheduled maintenance, instance state-change). Nodes that go unhealthy *without* an AWS-originated signal — kubelet crash, kernel deadlock, network partition, container runtime hang — are not surfaced through SQS and therefore stay tainted (`node.kubernetes.io/unreachable:NoExecute/NoSchedule`) indefinitely. Workload pods enter `Terminating` but can't finalize (no kubelet to confirm shutdown), which means the `WhenEmpty` consolidation policy never finds the node empty and never disrupts it.
+
+Observed 2026-05-19 on a production AWS deployment: a spot node went `NotReady` (kubelet stopped heart­beating); ~25 pods stayed `Terminating` for ~52 minutes before manual intervention. NodeClaim `Ready=True` and `Consolidatable=True` throughout — Karpenter had no mechanism to act on the bad Node Conditions.
+
+Enabling `nodeRepair: true` adds a second observation channel: Karpenter watches the Node Object's `Conditions` directly and, when any of `Ready=Unknown/False`, `KernelDeadlock=True`, `NetworkUnavailable=True`, `ContainerRuntimeNotReady=True`, or `ReadonlyFilesystem=True` persists for the per-condition threshold (~30 min, hardcoded in Karpenter v1.x), force-terminates the NodeClaim and reprovisions. NodeRepair bypasses PDBs, drain timeouts, and disruption budgets — the node is already dead, so there is nothing to protect.
+
+| Trigger source | Before | After |
+|---|---|---|
+| AWS-originated (spot reclaim, AZ rebalance, scheduled events) | SQS queue → Karpenter cordon+drain ✓ | unchanged ✓ |
+| Silent degradation (kubelet/runtime/network/kernel) | not detected — node tainted forever | NodeRepair force-replaces after ~30 min |
+| Consolidation (empty/underutilized) | NodePool `WhenEmpty` policy ✓ | unchanged ✓ |
+
+**Behavioral impact downstream.** AWS clusters consuming this chart will, after the platform-root promote, see Karpenter automatically replace nodes whose Conditions go bad. False-positive force-replacement of a transiently flapping node is possible but rare given the ~30 min stability window; the cost (~3 min of churn for one node) is materially less than the current failure mode (open-ended outage requiring manual `kubectl delete nodeclaim`). No-op for Azure clusters (gated on `provider == "aws"` in platform-root).
+
+**Operator runbook.** If NodeRepair fires unexpectedly often (more than a node/day in steady state), that indicates a deeper AMI / kernel / network issue that NodeRepair would be masking — investigate `karpenter` controller logs filtered on `reason=NodeRepair` and EC2 console for the affected instance IDs before disabling the gate.
+
 ## [0.39.14] — 2026-05-18
 
 ### Fixed — `workload-bootstrap`: ADR 0029 compliance — auto-prune on Safe-class templates

--- a/values/platform/karpenter.yaml
+++ b/values/platform/karpenter.yaml
@@ -54,5 +54,22 @@ settings:
   # between spot instances to reclaim cheaper capacity. Cleared by
   # default-false in the chart but enabled here to match the legacy
   # cortex production behaviour.
+  #
+  # nodeRepair lets Karpenter detect unhealthy Nodes via the
+  # Node Object Conditions (Ready=Unknown/False, KernelDeadlock,
+  # NetworkUnavailable, ContainerRuntimeNotReady, ReadonlyFilesystem)
+  # and force-terminate the underlying NodeClaim, triggering a fresh
+  # replacement. Complements the SQS interruption queue (which only
+  # surfaces AWS-originated events like spot reclaim) by covering the
+  # "kubelet silently died" class of failure — observed 2026-05-19
+  # on a production AWS deployment where a spot node went NotReady
+  # for ~52 minutes with no AWS-side notice; Karpenter's WhenEmpty
+  # consolidation couldn't disrupt it because Terminating pods kept
+  # the node non-empty, and no other mechanism existed to act on the
+  # bad Node Conditions. NodeRepair force-replaces the node ignoring
+  # PDBs/budgets (the node is already dead — nothing to protect).
+  # Beta in Karpenter v1.x with default-false; we enable it
+  # explicitly. Trigger duration is hardcoded per condition (~30m).
   featureGates:
     spotToSpotConsolidation: true
+    nodeRepair: true


### PR DESCRIPTION
## Summary

- Enable Karpenter `nodeRepair` feature gate in `values/platform/karpenter.yaml`.
- AWS-only change (Azure clusters gate this Application off in platform-root).
- No schema / no breaking changes; additive feature flag.

## Why

Karpenter v1.x ships with two observation channels for node lifecycle:

1. **SQS interruption queue** — covers AWS-originated events: spot reclaim, AZ rebalance, scheduled maintenance, instance state-change. Already enabled (`INTERRUPTION_QUEUE` env var).
2. **NodeRepair** — covers the failure mode where a node goes bad *without* an AWS-side signal: kubelet crash, kernel deadlock, container runtime hang, network partition. The controller watches `Node.status.conditions` directly and force-replaces the NodeClaim. **Disabled by default; this PR turns it on.**

Without NodeRepair, an unhealthy node stays tainted `node.kubernetes.io/unreachable:NoExecute/NoSchedule` forever. Pods enter `Terminating` but never finalize (no kubelet to confirm shutdown), so the NodePool's `WhenEmpty` consolidation policy never finds the node empty and never disrupts it. Recovery requires manual `kubectl delete nodeclaim`.

This was observed 2026-05-19 on a production AWS deployment: spot node went `NotReady`, ~25 pods stuck `Terminating` for ~52 minutes, NodeClaim `Ready=True` and `Consolidatable=True` throughout. No mechanism existed to act on the bad Node Conditions until human intervention.

## Trigger coverage after this change

| Failure class | Before | After |
|---|---|---|
| AWS-originated (spot reclaim, AZ rebalance, …) | SQS → cordon+drain ✓ | unchanged ✓ |
| Silent degradation (kubelet/runtime/kernel/network) | not detected — manual recovery only | NodeRepair force-replaces after ~30 min |
| Consolidation (empty/underutilized) | NodePool policy ✓ | unchanged ✓ |

## Trade-offs

- **Force-replace bypasses PDBs and disruption budgets.** Intentional: the node is already dead, there is nothing to protect. The pods are already in `Terminating`.
- **False-positive risk.** A transiently flapping node could be replaced. Mitigated by the ~30 min stability window before NodeRepair fires.
- **Cost of false positive (~3 min churn for one node) ≪ cost of current behaviour (open-ended outage).**

## Operator runbook

If NodeRepair fires unexpectedly often (>1 node/day in steady state), that indicates a deeper AMI / kernel / network issue being *masked* by NodeRepair — investigate `karpenter` controller logs filtered on `reason=NodeRepair` and EC2 console for the affected instance IDs before considering rollback.

## Test plan

- [ ] `helm template` of `karpenter` chart 1.12.0 against this values file renders `FEATURE_GATES` env var with `NodeRepair=true`.
- [ ] After merge + release commit + downstream bump + `estabilis promote` on **hml first**, verify on a hml node:
  - [ ] `kubectl -n karpenter get deploy karpenter -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="FEATURE_GATES")].value}'` includes `NodeRepair=true`.
  - [ ] Karpenter controller log shows `"node repair controller starting"` or equivalent (no `feature gate NodeRepair is disabled`).
- [ ] Observe for 1 week on hml; if no false-positive replacements, propagate to prd.
- [ ] (No automated synthetic test — production-realistic kubelet-kill simulation requires `aws ec2 terminate-instances` on a real spot, out of scope for CI.)

## Release / downstream propagation (post-merge)

1. Direct-push `chore(release): vX.Y.Z` commit bumping `workload-bootstrap/Chart.yaml` (version + appVersion) and `workload-bootstrap/values.yaml` (repoVersion). MINOR bump (new feature behavior).
2. Workflow auto-creates the tag.
3. Bump `estabilis-platform-downstream` template `overrides/platform-root/values.yaml` → `platformGitopsVersion`.
4. Per AWS client: bump `overrides/platform-root/values.yaml platformGitopsVersion` + `terraform.tfvars config_repo_version`, commit + tag.
5. `estabilis promote <client> -d <deployment> --force-refresh`. **hml first**, observe ≥1 week, then prd.