### PR TITLE
fix(network-policies): gate allow-traefik on traefik OR traefik-internal

### DIFF
--- a/components/network-policies/templates/policies.yaml
+++ b/components/network-policies/templates/policies.yaml
@@ -244,7 +244,7 @@ spec:
 # Egress: DNS, grafana namespace (backend routing)
 # Ingress: all (Azure Load Balancer, external traffic)
 # =============================================================================
-{{- if and .Values.policies.traefik.enabled (ne (.Values.components.traefik | toString) "false") }}
+{{- if and .Values.policies.traefik.enabled (or (ne (.Values.components.traefik | toString) "false") (eq (index .Values.components "traefik-internal" | default false | toString) "true")) }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/components/network-policies/values.yaml
+++ b/components/network-policies/values.yaml
@@ -23,6 +23,7 @@ components:
   cnpg: true
   kyverno: true
   traefik: true
+  traefik-internal: false
   velero: true
   opencost: true
   trivy: true
@@ -67,6 +68,8 @@ policies:
   kyverno:
     enabled: true
   traefik:
+    enabled: true
+  traefik-internal:
     enabled: true
   velero:
     enabled: true

--- a/values/platform/cert-manager.yaml
+++ b/values/platform/cert-manager.yaml
@@ -79,3 +79,6 @@ startupapicheck:
       drop: [ALL]
     seccompProfile:
       type: RuntimeDefault
+
+dns01RecursiveNameservers: "1.1.1.1:53,8.8.8.8:53"
+dns01RecursiveNameserversOnly: true


### PR DESCRIPTION
## Summary

- **Network policy fix**: The `allow-traefik` NetworkPolicy was only gated on `components.traefik`. Deployments using `components.traefik-internal=true` (ILB-only, no public Traefik) with `components.traefik=false` had no allow policy, causing Kyverno default-deny to block all ingress/egress to Traefik. The gate now fires when EITHER component is enabled.
- **cert-manager DNS-01 fix**: Adds `dns01RecursiveNameservers` (Cloudflare + Google public resolvers) and `dns01RecursiveNameserversOnly: true` to platform cert-manager values, so DNS-01 ACME challenges resolve correctly for domains in Azure Private DNS Zones without public NS delegation.

## Changes

| File | Change |
|------|--------|
| `components/network-policies/templates/policies.yaml` | Gate `allow-traefik` on `traefik OR traefik-internal` |
| `components/network-policies/values.yaml` | Add `traefik-internal: false` component + `traefik-internal.enabled: true` policy |
| `values/platform/cert-manager.yaml` | Add `dns01RecursiveNameservers` + `dns01RecursiveNameserversOnly` |

## Test plan

- [ ] `helm template` the network-policies chart with `components.traefik=false` + `components.traefik-internal=true` — confirm `allow-traefik` NetworkPolicy is rendered
- [ ] `helm template` with both `traefik=false` + `traefik-internal=false` — confirm `allow-traefik` is NOT rendered
- [ ] `helm template` with default values (traefik=true, traefik-internal=false) — confirm `allow-traefik` still renders (no regression)
- [ ] Verify cert-manager DNS-01 challenge succeeds on a cluster with Azure Private DNS Zone