### PR TITLE
feat: external-dns-public-dnat variant for DNAT-gateway split DNS (v0.42.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.42.7] - 2026-06-06
+
+### Added
+
+- **`external-dns-public-dnat` ApplicationSet** — public external-dns variant for
+  workload clusters fronted by a DNAT gateway (FortiGate/NVA). Selected by the
+  per-cluster gate label `estabilis.io/addon.public-dns` (stamped by
+  estabilis-workload-operator >= v0.10.4 from the `public-dns-enabled` bridge
+  key set by estabilis-workload >= v3.5.1). On top of the base public
+  external-dns it adds `excludeDomains[0]` = the internal split-horizon domain
+  (`bridge.internal-domain`) and `extraArgs` `--default-targets=<bridge.ingress-public-ip>`
+  + `--force-default-targets`, so the public (Cloudflare) zone publishes the
+  gateway VIP instead of the private ILB and stops leaking the `.azure` internal
+  hostnames.
+
+### Changed
+
+- **Base `external-dns` ApplicationSet** now carries a `matchExpressions` selector
+  `estabilis.io/addon.public-dns DoesNotExist`, making it mutually exclusive with
+  `external-dns-public-dnat`: exactly one external-dns variant targets each
+  workload cluster. Clusters without the label (incl. NAT-Gateway topology) keep
+  the existing base behavior unchanged.
+
 ## [0.42.6] - 2026-06-01
 
 ### Fixed

--- a/workload-bootstrap/Chart.yaml
+++ b/workload-bootstrap/Chart.yaml
@@ -5,5 +5,5 @@ description: |
   workload cluster registered by the estabilis-workload-operator.
   Rendered by the hub's ArgoCD. See ADR 0001.
 type: application
-version: 0.42.6
-appVersion: "0.42.6"
+version: 0.42.7
+appVersion: "0.42.7"

--- a/workload-bootstrap/templates/external-dns-public-dnat.yaml
+++ b/workload-bootstrap/templates/external-dns-public-dnat.yaml
@@ -1,0 +1,115 @@
+{{- /*
+  Public external-dns — DNAT-gateway (FortiGate/NVA) variant.
+
+  Mutually exclusive with external-dns.yaml (the BASE public external-dns):
+  - BASE selects clusters where estabilis.io/addon.public-dns DoesNotExist.
+  - THIS selects clusters where estabilis.io/addon.public-dns == "true".
+  Exactly one of the two matches each workload cluster, so a cluster runs a
+  single external-dns release named "external-dns" either way.
+
+  Per-cluster gate (ADR 0010): the operator stamps estabilis.io/addon.public-dns
+  from the bridge key public-dns-enabled (= workload TF var public_ingress_ip
+  is non-empty). Only clusters fronted by a DNAT gateway opt in.
+
+  Delta vs BASE (the split-DNS fix for spoke clusters behind FortiGate):
+    - excludeDomains[0] = the internal split-horizon domain → stop *.azure.<domain>
+      from leaking into the public (Cloudflare) zone.
+    - extraArgs --default-targets=<ingress-public-ip VIP> + --force-default-targets
+      → publish the public gateway VIP instead of the private ILB the Service
+      status carries. force is REQUIRED: --default-targets alone is only a
+      fallback and does not override an already-derivable target (the private
+      ILB). external-dns 0.20.0 / chart 1.20.0.
+  These three params are UNCONDITIONAL here because this AppSet only ever targets
+  clusters that carry the VIP (ingress-public-ip) + internal-domain annotations —
+  so no empty-value/no-op-filler problem (ArgoCD goTemplate cannot conditionally
+  omit a list item; gating is done by the selector, not in the template).
+
+  Forward-compatible with ADR 0039: when the two-lane bridge lands, the
+  addon.public-dns gate label becomes estabilis.io/capability.<name> by prefix
+  convention and this variant can fold back into a single catalog entry.
+
+  Sync-wave 7 — same as the base public external-dns.
+*/ -}}
+{{- if index .Values.components "external-dns" }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: external-dns-public-dnat
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - clusters:
+        selector:
+          matchLabels:
+            {{- toYaml .Values.clusterSelector.matchLabels | nindent 12 }}
+            # Per-cluster gate: operator stamps this from bridge key
+            # public-dns-enabled (workload TF var public_ingress_ip != "").
+            estabilis.io/addon.public-dns: "true"
+  template:
+    metadata:
+      # Same name + releaseName as the BASE variant: a cluster runs ONE
+      # external-dns release. Selectors are mutually exclusive, so only one
+      # AppSet generates this Application per cluster. NOTE: when a cluster first
+      # acquires the addon.public-dns label, ownership of external-dns-<cluster>
+      # hands over from the base AppSet (prunes) to this one (adopts) — a
+      # one-time, transient handover per cluster at cutover.
+      name: "external-dns-{{ `{{ .name }}` }}"
+      annotations:
+        argocd.argoproj.io/sync-wave: "7"
+      labels:
+        estabilis.io/workload-cluster: "{{ `{{ .name }}` }}"
+    spec:
+      project: workload-baseline
+      sources:
+        - repoURL: https://kubernetes-sigs.github.io/external-dns
+          chart: external-dns
+          targetRevision: "1.20.0"
+          helm:
+            releaseName: "external-dns"
+            valueFiles:
+              - $values/values/workload/external-dns.yaml
+              - $values/values/workload/external-dns-{{ `{{ index .metadata.annotations "estabilis.io/bridge.dns-provider" }}` }}.yaml
+              {{- include "workload-bootstrap.overrideValueFile" (dict "component" "external-dns" "root" $) | nindent 14 }}
+              {{- include "workload-bootstrap.gitopsValueFile" (dict "component" "external-dns" "root" $) | nindent 14 }}
+            {{- include "workload-bootstrap.ignoreMissingValueFiles" . | nindent 12 }}
+            parameters:
+              - name: domainFilters[0]
+                value: '{{ `{{ index .metadata.annotations "estabilis.io/bridge.domain" }}` }}'
+              - name: txtOwnerId
+                value: '{{ `{{ .name }}` }}'
+              - name: serviceAccount.annotations.azure\.workload\.identity/client-id
+                value: '{{ `{{ index .metadata.annotations "estabilis.io/bridge.external-dns-client-id" }}` }}'
+              - name: zoneIdFilters[0]
+                value: '{{ `{{ index .metadata.annotations "estabilis.io/bridge.cloudflare-zone-id" }}` }}'
+              # --- DNAT split-DNS delta (vs BASE) ---
+              - name: excludeDomains[0]
+                value: '{{ `{{ index .metadata.annotations "estabilis.io/bridge.internal-domain" }}` }}'
+              - name: extraArgs[0]
+                value: '--default-targets={{ `{{ index .metadata.annotations "estabilis.io/bridge.ingress-public-ip" }}` }}'
+              - name: extraArgs[1]
+                value: '--force-default-targets'
+              {{- include "workload-bootstrap.provenanceParameters" $ | nindent 14 }}
+        - repoURL: {{ .Values.repoURL | quote }}
+          targetRevision: {{ .Values.repoVersion | quote }}
+          ref: values
+        {{- include "workload-bootstrap.overrideSource" . | nindent 8 }}
+        {{- include "workload-bootstrap.gitopsSource" . | nindent 8 }}
+      destination:
+        server: "{{ `{{ .server }}` }}"
+        namespace: "external-dns"
+      syncPolicy:
+        {{- include "workload-bootstrap.managedNamespaceMetadata" . | nindent 8 }}
+        automated:
+          selfHeal: true
+        retry:
+          limit: 10
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m
+        syncOptions:
+          - CreateNamespace=true
+{{- end }}

--- a/workload-bootstrap/templates/external-dns.yaml
+++ b/workload-bootstrap/templates/external-dns.yaml
@@ -13,6 +13,14 @@ spec:
         selector:
           matchLabels:
             {{- toYaml .Values.clusterSelector.matchLabels | nindent 12 }}
+          # Mutually exclusive with external-dns-public-dnat.yaml: clusters whose
+          # operator stamped estabilis.io/addon.public-dns (DNAT/FortiGate
+          # topology, from bridge key public-dns-enabled) get the public-DNAT
+          # variant instead — this BASE variant covers everyone else (incl.
+          # NAT-Gateway clusters). Exactly one of the two matches each cluster.
+          matchExpressions:
+            - key: estabilis.io/addon.public-dns
+              operator: DoesNotExist
   template:
     metadata:
       name: "external-dns-{{ `{{ .name }}` }}"

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -14,7 +14,7 @@
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.42.6
+repoVersion: v0.42.7
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
## What

Adds the `external-dns-public-dnat` ApplicationSet — a public external-dns variant for workload (spoke) clusters fronted by a DNAT gateway (FortiGate/NVA). Selected by the per-cluster gate label `estabilis.io/addon.public-dns` (stamped by estabilis-workload-operator >= v0.10.4 from the `public-dns-enabled` bridge key set by estabilis-workload >= v3.5.1).

On top of the base public external-dns it adds:
- `excludeDomains[0]` = `bridge.internal-domain` → stop `.azure` split-horizon hostnames leaking into the public (Cloudflare) zone.
- `extraArgs` `--default-targets=<bridge.ingress-public-ip>` + `--force-default-targets` → publish the gateway VIP instead of the private ILB the Service status carries.

The base `external-dns` AppSet gains a `matchExpressions` selector `estabilis.io/addon.public-dns DoesNotExist`, making the two **mutually exclusive** — exactly one external-dns variant targets each workload cluster. Clusters without the label (incl. NAT-Gateway topology, and crypto/brazilsouth) keep the existing base behavior unchanged.

## Why

Per-cluster split-DNS fix for spoke clusters behind FortiGate: the public zone must point at the gateway VIP, and the internal domain must not leak. ArgoCD goTemplate cannot conditionally omit a list item, and an empty `--default-targets` + `--force-default-targets` is unsafe — so gating is done by selector (label), via a mutually-exclusive second AppSet, not by conditional params. Forward-compatible with ADR 0039 (the `capability.*` convention will let this fold back into one catalog entry).

## Release

Bumps chart `version` + `appVersion` (0.42.7) and `values.yaml` `repoVersion` (v0.42.7). `chore(release): v0.42.7` is HEAD. **Merge via "Rebase and merge"** (not squash) so the release commit lands as HEAD on `main` and the auto-tag fires.