### PR TITLE
fix: base external-dns excludes the internal split-horizon domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.42.8] - 2026-06-07
+
+### Fixed
+
+- **Base `external-dns` (public/Cloudflare) now excludes the internal split-horizon
+  domain.** Added `excludeDomains[0] = bridge.internal-domain` to the base
+  `external-dns` ApplicationSet parameters (mirrors `external-dns-public-dnat`,
+  without `--force-default-targets`). Without it, a base-variant cluster (no
+  FortiGate, e.g. brazilsouth crypto) published its `*.{internal-domain}` hosts
+  into the public Cloudflare zone pointing at the ILB private IP — a leak. The
+  internal hosts remain owned by `external-dns-internal` (Azure Private DNS).
+  No effect on clusters whose `internal-domain` bridge key is empty.
+
 ## [0.42.7] - 2026-06-06
 
 ### Added

--- a/workload-bootstrap/templates/external-dns.yaml
+++ b/workload-bootstrap/templates/external-dns.yaml
@@ -51,6 +51,13 @@ spec:
                 value: '{{ `{{ index .metadata.annotations "estabilis.io/bridge.external-dns-client-id" }}` }}'
               - name: zoneIdFilters[0]
                 value: '{{ `{{ index .metadata.annotations "estabilis.io/bridge.cloudflare-zone-id" }}` }}'
+              # Never publish the internal split-horizon domain to the public DNS
+              # (Cloudflare): *.{internal-domain} is owned by external-dns-internal
+              # (Azure Private DNS). Without this the public external-dns leaks the
+              # internal hosts (pointing at the ILB private IP) into the public zone.
+              # Mirrors the external-dns-public-dnat variant (minus --force-default-targets).
+              - name: excludeDomains[0]
+                value: '{{ `{{ index .metadata.annotations "estabilis.io/bridge.internal-domain" }}` }}'
               {{- include "workload-bootstrap.provenanceParameters" $ | nindent 14 }}
         - repoURL: {{ .Values.repoURL | quote }}
           targetRevision: {{ .Values.repoVersion | quote }}


### PR DESCRIPTION
## Problema
O base `external-dns` (público/Cloudflare) não exclui o domínio interno split-horizon. Num cluster base-variant sem FortiGate (ex.: brazilsouth crypto), ele publica `*.{internal-domain}` (ex.: `*.azure.transfero.dev`) na zona pública do Cloudflare apontando o **IP privado do ILB** — vazamento. Os clusters FortiGate (b2c/corporate/payments) já não sofrem disso por estarem na variante `external-dns-public-dnat` (que exclui).

## Fix
Adiciona `excludeDomains[0] = bridge.internal-domain` aos parameters do AppSet base `external-dns` — espelha o `external-dns-public-dnat`, **sem** `--force-default-targets`. Os hosts internos seguem sendo publicados só pelo `external-dns-internal` (Azure Private DNS). Sem efeito quando `internal-domain` está vazio.

## Release
Após merge, um commit `chore(release): v0.42.8` no main dispara tag + release.