### PR TITLE
fix: public workload Traefik filters by ingressClass=traefik

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.42.9] - 2026-06-08
+
+### Fixed
+
+- **Public workload Traefik now filters by `ingressClass: traefik`.** The public
+  and internal Traefik share the controller `traefik.io/ingress-controller` and
+  `traefik` is the default IngressClass, so without a provider `ingressClass`
+  filter the public Traefik also claimed the `traefik-internal` Ingresses and
+  wrote its public LB IP into their `.status`, fighting the internal Traefik. The
+  internal Ingress status (and the Azure Private DNS records published from it)
+  flapped between the ILB IP and the public LB IP — internal hostnames
+  intermittently resolved to the PUBLIC IP. `values/workload/traefik.yaml` now
+  sets `providers.{kubernetesIngress,kubernetesCRD}.ingressClass: traefik`,
+  mirroring the `traefik-internal` overlay. Only affects clusters running the
+  public Traefik (e.g. brazilsouth crypto); backward-compatible.
+
 ## [0.42.8] - 2026-06-07
 
 ### Fixed

--- a/values/workload/traefik.yaml
+++ b/values/workload/traefik.yaml
@@ -29,11 +29,19 @@ service:
     externalTrafficPolicy: Local
 
 providers:
+  # ingressClass FILTER: este Traefik público processa SÓ a classe `traefik`.
+  # Sem o filtro ele reivindica também os Ingress `traefik-internal` (as duas
+  # IngressClasses compartilham o controller traefik.io/ingress-controller, e
+  # `traefik` é a default) e escreve seu publishedService no status deles —
+  # brigando com o Traefik interno → o status IP dos Ingress internos flapa entre
+  # o ILB e o LB público. Espelha o filtro do overlay traefik-internal.
   kubernetesCRD:
     enabled: true
     allowCrossNamespace: true
+    ingressClass: traefik
   kubernetesIngress:
     enabled: true
+    ingressClass: traefik
 
 logs:
   general:


### PR DESCRIPTION
## Problema
Os dois Traefik de workload (público + interno) compartilham o controller `traefik.io/ingress-controller` e `traefik` é a IngressClass default. O público **não tinha filtro de ingressClass**, então reivindicava também os Ingress `traefik-internal` e escrevia seu LB público no `.status` deles, brigando com o interno. O status dos Ingress internos (e os registros Azure Private DNS derivados) **flapava** entre o ILB e o LB público — hostnames internos resolvendo pro IP **público** de forma intermitente (verificado no crypto brazilsouth).

## Fix
`providers.{kubernetesIngress,kubernetesCRD}.ingressClass: traefik` em `values/workload/traefik.yaml`, espelhando o overlay `traefik-internal`. Só afeta clusters com o Traefik público (crypto); backward-compatible.

## Release
Após merge, commit `chore(release): v0.42.9` no main dispara tag + release.