### PR TITLE
fix: bump workload-bootstrap repoVersion to v0.42.10 (propaga fix do traefik)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and the corresponding commit messages.
 
 ## [Unreleased]
 
+## [0.42.10] - 2026-06-08
+
+### Fixed
+
+- **`workload-bootstrap.repoVersion` bumped to v0.42.10** (was stuck at `v0.42.7`).
+  Nested Applications read their `$values` (e.g. `values/workload/traefik.yaml`)
+  from this revision, NOT from the chart's own `targetRevision`. It is a manually
+  kept literal and was not bumped for 0.42.8/0.42.9, so the **v0.42.9 public-Traefik
+  `ingressClass` fix never reached the workloads** (template/parameter changes
+  propagate with the chart version; values-file changes propagate via `repoVersion`).
+  This release makes `repoVersion` match so the Traefik fix lands. Follow-up: have
+  `platform-root` pass `repoVersion = platformGitopsVersion` to remove this footgun.
+
 ## [0.42.9] - 2026-06-08
 
 ### Fixed

--- a/workload-bootstrap/values.yaml
+++ b/workload-bootstrap/values.yaml
@@ -13,8 +13,13 @@
 # Version of this repo (estabilis-platform-gitops) that nested Applications
 # should pin to when reading $values. Kept in sync with the hub Application's
 # targetRevision so $values always matches the rendered templates.
+# ⚠️ DEVE ser bumpado em TODO release — senão mudanças em values/workload/*.yaml
+# NÃO propagam (o chart vem da nova versão via platformGitopsVersion, mas os
+# AppSets filhos leem $values daqui). Ficou preso em v0.42.7 e o fix do traefik
+# (v0.42.9) não chegou aos workloads até este bump. (Idealmente o platform-root
+# passaria repoVersion = platformGitopsVersion p/ eliminar este footgun.)
 repoURL: https://github.com/Estabilis/estabilis-platform-gitops.git
-repoVersion: v0.42.7
+repoVersion: v0.42.10
 
 # Version of estabilis-platform (the HUB-side repo) that rendered this chart.
 # Passed as a helm parameter by the parent Application


### PR DESCRIPTION
## Problema
Os AppSets filhos do workload-bootstrap leem seus `$values` (ex.: `values/workload/traefik.yaml`) na revisão **`repoVersion`** — um literal manual em `workload-bootstrap/values.yaml`, NÃO o `targetRevision` do chart. Ficou preso em `v0.42.7` e não foi bumpado p/ 0.42.8/0.42.9.

Resultado: o fix do **ingressClass do Traefik público (v0.42.9)** — que é mudança em **values-file** — **não chegou aos workloads** (o crypto seguia flapando). Mudanças de template/parameters (ex.: external-dns exclude v0.42.8) propagam com o chart e funcionaram; values-files dependem do `repoVersion`.

## Fix
Bump `repoVersion` → `v0.42.10`. Follow-up recomendado: `platform-root` passar `repoVersion = platformGitopsVersion` p/ eliminar o sync manual.

## Release
Após merge, `chore(release): v0.42.10`.